### PR TITLE
Refresh tokens for matrix integration

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,7 +12,7 @@
         "dotenv": "^16.5.0",
         "drizzle-orm": "^0.42.0",
         "hono": "^4.7.7",
-        "matrix-js-sdk": "^37.3.0",
+        "matrix-js-sdk": "^37.4.0",
         "postgres": "^3.4.5",
         "tsx": "^4.19.3",
         "zod": "^3.24.3"
@@ -1949,10 +1949,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/matrix-js-sdk": {
-      "version": "37.3.0",
-      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-37.3.0.tgz",
-      "integrity": "sha512-uYpXEucA+y9b116Hn+zG+X+u2GE2dACh+aN0BhiJDL/LtvhQgrXT4ZLG/N7OizomoHHF+i/WetDhi+rzDJQdDw==",
-      "license": "Apache-2.0",
+      "version": "37.4.0",
+      "resolved": "https://registry.npmjs.org/matrix-js-sdk/-/matrix-js-sdk-37.4.0.tgz",
+      "integrity": "sha512-blNkfswy9PbzXJor/SErL7KCj6ZC7n+PjeA20spikWyyLNBl/+duS4Noc9Cnf82mERbuFOIms5eN4Mcqn9Q7xw==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@matrix-org/matrix-sdk-crypto-wasm": "^14.0.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,7 @@
     "dotenv": "^16.5.0",
     "drizzle-orm": "^0.42.0",
     "hono": "^4.7.7",
-    "matrix-js-sdk": "^37.3.0",
+    "matrix-js-sdk": "^37.4.0",
     "postgres": "^3.4.5",
     "tsx": "^4.19.3",
     "zod": "^3.24.3"

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { db } from "./db/db.js";
 import { messagesTable } from "./db/schema.js";
 
-// const isDevelopment = process.env.NODE_ENV === "development";
+const isDevelopment = process.env.NODE_ENV === "development";
 
 export function createApp() {
   const app = new Hono();
@@ -16,7 +16,7 @@ export function createApp() {
 
   app.use(
     cors({
-      origin: ["http://localhost:5173", "*"],
+      origin: isDevelopment ? ["http://localhost:5173"] : ["*"],
     })
   );
 

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -16,7 +16,7 @@ export function createApp() {
 
   app.use(
     cors({
-      origin: isDevelopment ? ["http://localhost:5173"] : ["*"],
+      origin: isDevelopment ? ["http://localhost:5173"] : "*",
     })
   );
 

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -4,8 +4,10 @@ import { z } from "zod";
 
 export const envSchema = z.object({
   HOMESERVER_URL: z.string().url(),
-  ACCESS_TOKEN: z.string().min(1),
+  ACCESS_TOKEN: z.string().min(1).optional(),
   USER_ID: z.string().min(1),
+  MATRIX_USERNAME: z.string().min(1),
+  MATRIX_PASSWORD: z.string().min(1),
   ROOM_IDS: z
     .string()
     .min(1)

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,7 +14,9 @@ async function main() {
         env.HOMESERVER_URL,
         env.ACCESS_TOKEN,
         env.USER_ID,
-        msgLog
+        msgLog,
+        env.MATRIX_USERNAME,
+        env.MATRIX_PASSWORD
       );
 
   const app = createApp();

--- a/backend/src/services/matrix.ts
+++ b/backend/src/services/matrix.ts
@@ -90,10 +90,9 @@ export class MatrixService {
           ClientEvent.Sync,
           (
             state: SyncState,
-            prevState: SyncState | null,
+            _prevState: SyncState | null,
             data?: ISyncStateData
           ) => {
-            console.log("state", state, prevState, data?.error?.name);
             if (state === "ERROR" && data?.error?.name === "M_UNKNOWN_TOKEN") {
               console.log("🚨 Matrix client is in error state");
               reject("Matrix token expired - incorrect initial credentials");

--- a/backend/src/services/matrix.ts
+++ b/backend/src/services/matrix.ts
@@ -3,70 +3,269 @@ import {
   type MatrixClient,
   RoomEvent,
   createClient,
+  MatrixError,
 } from "matrix-js-sdk";
 import type { MessagesLogger } from "./logger.js";
 
+interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+  userId: string;
+  expiresInMs?: number;
+}
+
 export class MatrixService {
-  private client: MatrixClient;
+  private client?: MatrixClient;
+  private isRefreshing = false;
+  private refreshToken?: string;
+  private tokenExpiryTime?: number;
 
   constructor(
     private homeserverUrl: string,
-    private accessToken: string,
+    private accessToken: string | undefined,
     private userId: string,
-    private msgLog: MessagesLogger
-  ) {
-    this.client = createClient({
+    private msgLog: MessagesLogger,
+    private username: string,
+    private password: string
+  ) {}
+
+  private async authenticate(): Promise<AuthTokens> {
+    if (!this.username || !this.password) {
+      throw new Error("Matrix username or password not set");
+    }
+
+    console.log("🔑 Performing Matrix login...");
+
+    // Create a temporary client without token for login
+    const tempClient = createClient({
       baseUrl: this.homeserverUrl,
-      accessToken: this.accessToken,
-      userId: this.userId,
     });
+
+    try {
+      // Perform login to get a fresh token
+      const response = await tempClient.loginRequest({
+        type: "m.login.password",
+        user: this.username,
+        password: this.password,
+        refresh_token: true,
+      });
+
+      console.log("✅ Successfully authenticated with Matrix");
+
+      // Check if expires_in_ms is available in the response
+      if (response.expires_in_ms) {
+        console.log(
+          `✓ Token will expire in ${Math.round(
+            response.expires_in_ms / (1000 * 60 * 60)
+          )} hours`
+        );
+      }
+
+      return {
+        accessToken: response.access_token,
+        refreshToken: response.refresh_token || "",
+        userId: response.user_id || this.userId,
+        expiresInMs: response.expires_in_ms,
+      };
+    } catch (error) {
+      console.error("❌ Matrix authentication failed:", error);
+      throw error;
+    }
+  }
+
+  private async refreshAccessToken(): Promise<AuthTokens> {
+    if (!this.refreshToken) {
+      // If no refresh token, fall back to password authentication
+      return this.authenticate();
+    }
+
+    try {
+      console.log("🔄 Refreshing Matrix access token using refresh token...");
+
+      // Create temporary client for token refresh
+      const tempClient = createClient({
+        baseUrl: this.homeserverUrl,
+      });
+
+      // The refreshToken method in matrix-js-sdk
+      const response = await tempClient.refreshToken(this.refreshToken);
+
+      console.log("✅ Successfully refreshed Matrix access token");
+
+      // Check if expires_in_ms is available in the response
+      if (response.expires_in_ms) {
+        console.log(
+          `✓ Refreshed token will expire in ${Math.round(
+            response.expires_in_ms / (1000 * 60 * 60)
+          )} hours`
+        );
+      }
+
+      return {
+        accessToken: response.access_token,
+        refreshToken: response.refresh_token || this.refreshToken,
+        userId: this.userId,
+        expiresInMs: response.expires_in_ms,
+      };
+    } catch (error) {
+      console.error(
+        "❌ Failed to refresh token, falling back to password auth:",
+        error
+      );
+      // If refresh token is invalid or expired, fall back to password authentication
+      return this.authenticate();
+    }
+  }
+
+  async createMatrixClient(): Promise<MatrixClient> {
+    if (this.isRefreshing) {
+      throw new Error("Already refreshing client");
+    }
+
+    this.isRefreshing = true;
+
+    try {
+      let tokens: AuthTokens;
+
+      // Use existing token if valid, otherwise authenticate
+      if (this.accessToken && !this.tokenExpired()) {
+        tokens = {
+          accessToken: this.accessToken,
+          refreshToken: this.refreshToken || "",
+          userId: this.userId,
+        };
+      } else if (this.refreshToken) {
+        // Try to refresh using refresh token
+        tokens = await this.refreshAccessToken();
+      } else {
+        // First time or fallback: authenticate with username/password
+        tokens = await this.authenticate();
+      }
+
+      // Update internal state with new tokens
+      this.accessToken = tokens.accessToken;
+      this.refreshToken = tokens.refreshToken;
+      this.userId = tokens.userId;
+
+      // Calculate token expiry time based on expires_in_ms from the response
+      // If expires_in_ms is not available, use a reasonable default of 12 hours
+      // Add a 5-minute buffer to refresh slightly before actual expiration
+      const buffer = 5 * 60 * 1000; // 5 minutes in milliseconds
+      const defaultExpiry = 12 * 60 * 60 * 1000; // 12 hours in milliseconds
+
+      this.tokenExpiryTime =
+        Date.now() +
+        (tokens.expiresInMs ? tokens.expiresInMs - buffer : defaultExpiry);
+
+      console.log(
+        `⏰ Token expiry set to ${new Date(this.tokenExpiryTime).toISOString()}`
+      );
+
+      // Create client with the new tokens
+      return createClient({
+        baseUrl: this.homeserverUrl,
+        accessToken: this.accessToken,
+        userId: this.userId,
+      });
+    } finally {
+      this.isRefreshing = false;
+    }
+  }
+
+  private tokenExpired(): boolean {
+    return (
+      !this.accessToken ||
+      (this.tokenExpiryTime !== undefined && Date.now() >= this.tokenExpiryTime)
+    );
   }
 
   async start() {
-    this.client.startClient();
+    try {
+      this.client = await this.createMatrixClient();
 
-    await new Promise<void>((resolve) => {
-      this.client.once(ClientEvent.Sync, (state: string) => {
-        if (state === "PREPARED") {
-          console.log("✅ Matrix client is ready and synced!");
-          resolve();
+      // Start the client
+      this.client.startClient();
+
+      await new Promise<void>((resolve) => {
+        this.client!.once(ClientEvent.Sync, (state: string) => {
+          if (state === "PREPARED") {
+            console.log("✅ Matrix client is ready and synced!");
+            resolve();
+          }
+        });
+      });
+
+      // Set up error handler for token issues
+      this.client.on("sync.error" as any, async (error: Error) => {
+        if (error instanceof MatrixError) {
+          if (
+            error.errcode === "M_UNKNOWN_TOKEN" ||
+            error.message.includes("Token is not active") ||
+            error.data?.error?.includes("Token is not active")
+          ) {
+            console.warn("🚨 Matrix token expired, attempting to refresh...");
+            await this.stop();
+            await this.handleTokenRefresh();
+          }
         }
       });
-    });
 
-    this.client.on(RoomEvent.Timeline, (event, room) => {
-      const roomId = room?.roomId;
-      const messageContent = event.getContent().body;
+      this.client.on(RoomEvent.Timeline, (event, room) => {
+        const roomId = room?.roomId;
+        const messageContent = event.getContent().body;
 
+        if (
+          !roomId ||
+          !this.msgLog.getRoomIds().includes(roomId) ||
+          !messageContent
+        ) {
+          return;
+        }
+
+        const sender = event.getSender();
+        const eventId = event.getId();
+        const timestamp = event.getDate();
+
+        if (typeof messageContent === "string") {
+          this.msgLog.onMessage(
+            roomId,
+            messageContent,
+            sender,
+            eventId,
+            timestamp
+          );
+        }
+      });
+
+      return this.client;
+    } catch (error) {
+      console.error("❌ Error starting Matrix client:", error);
       if (
-        !roomId ||
-        !this.msgLog.getRoomIds().includes(roomId) ||
-        !messageContent
+        error instanceof MatrixError &&
+        (error.errcode === "M_UNKNOWN_TOKEN" ||
+          error.message.includes("Token is not active") ||
+          error.data?.error?.includes("Token is not active"))
       ) {
-        return;
+        await this.handleTokenRefresh();
       }
+      throw error;
+    }
+  }
 
-      const sender = event.getSender();
-      const eventId = event.getId();
-      const timestamp = event.getDate();
-
-      if (typeof messageContent === "string") {
-        this.msgLog.onMessage(
-          roomId,
-          messageContent,
-          sender,
-          eventId,
-          timestamp
-        );
-      }
-    });
-
-    return this.client;
+  private async handleTokenRefresh() {
+    try {
+      this.client = await this.createMatrixClient();
+      await this.start();
+    } catch (error) {
+      console.error("❌ Failed to refresh client after token expiry:", error);
+      throw error;
+    }
   }
 
   async stop() {
     if (this.client) {
       await this.client.stopClient();
+      this.client = undefined;
     }
   }
 }

--- a/backend/src/utils/fill-historical-messages.ts
+++ b/backend/src/utils/fill-historical-messages.ts
@@ -1,85 +1,80 @@
 import { db } from "../db/db.js";
 import { env } from "../env.js";
 import { MessagesLogger } from "../services/logger.js";
+import { MatrixService } from "../services/matrix.js";
 
 export async function fetchAndInsertHistoricalMessages(
   roomIds: string[],
   daysBack = 30
 ) {
-  const { ClientEvent, createClient } = await import("matrix-js-sdk");
-
-  const client = createClient({
-    baseUrl: env.HOMESERVER_URL,
-    accessToken: env.ACCESS_TOKEN,
-    userId: env.USER_ID,
-  });
-
   const logger = new MessagesLogger({ roomIds, db });
   const daysAgo = new Date();
   daysAgo.setDate(daysAgo.getDate() - daysBack);
 
-  for (const roomId of roomIds) {
-    // Start the client
-    await client.startClient({ initialSyncLimit: 1000 });
+  // Create Matrix service with automatic token refresh
+  const matrixService = new MatrixService(
+    env.HOMESERVER_URL,
+    env.ACCESS_TOKEN, // Optional now
+    env.USER_ID,
+    logger,
+    env.MATRIX_USERNAME,
+    env.MATRIX_PASSWORD
+  );
 
-    // Wait for the client to be ready
-    await new Promise<void>((resolve) => {
-      client.once(ClientEvent.Sync, (state: string) => {
-        if (state === "PREPARED") {
-          console.log("Client is ready and synced!");
-          resolve();
+  // Start client with token refresh capability
+  const client = await matrixService.start();
+
+  try {
+    for (const roomId of roomIds) {
+      try {
+        console.log(`Fetching messages for room ${roomId}`);
+
+        const room = client.getRoom(roomId);
+        if (!room) {
+          console.error(`Room ${roomId} not found`);
+          continue;
         }
-      });
-    });
 
-    try {
-      console.log(`Fetching messages for room ${roomId}`);
+        // Get room timeline
+        const timeline = await room.getLiveTimeline();
+        const events = timeline.getEvents();
+        console.log("EVENTS", events.length);
+        const messages = [];
+        for (const event of events) {
+          if (event.getType() === "m.room.message") {
+            const content = event.getContent();
+            const messageContent = content.body;
 
-      const room = client.getRoom(roomId);
-      if (!room) {
-        console.error(`Room ${roomId} not found`);
-        continue;
-      }
+            if (typeof messageContent === "string") {
+              const sender = event.getSender();
+              const eventId = event.getId();
+              const timestamp = event.getDate();
 
-      // Get room timeline
-      const timeline = await room.getLiveTimeline();
-      const events = timeline.getEvents();
-      console.log("EVENTS", events.length);
-      const messages = [];
-      for (const event of events) {
-        if (event.getType() === "m.room.message") {
-          const content = event.getContent();
-          const messageContent = content.body;
-
-          if (typeof messageContent === "string") {
-            const sender = event.getSender();
-            const eventId = event.getId();
-            const timestamp = event.getDate();
-
-            if (eventId && timestamp && timestamp >= daysAgo) {
-              try {
-                messages.push({
-                  roomId,
-                  msg: messageContent,
-                  sender,
-                  eventId,
-                  date: timestamp,
-                });
-              } catch (error) {
-                console.error(`Error processing message ${eventId}:`, error);
+              if (eventId && timestamp && timestamp >= daysAgo) {
+                try {
+                  messages.push({
+                    roomId,
+                    msg: messageContent,
+                    sender,
+                    eventId,
+                    date: timestamp,
+                  });
+                } catch (error) {
+                  console.error(`Error processing message ${eventId}:`, error);
+                }
               }
             }
           }
         }
+        console.log("Adding messages", roomId, messages.length);
+        await logger.onMessages(messages);
+      } catch (error) {
+        console.error(`Error processing room ${roomId}:`, error);
       }
-      console.log("Adding messages", roomId, messages.length);
-      await logger.onMessages(messages);
-    } catch (error) {
-      console.error(`Error processing room ${roomId}:`, error);
     }
-
+  } finally {
     // Stop the client
-    client.stopClient();
+    await matrixService.stop();
   }
 }
 


### PR DESCRIPTION
Let's keep it open till tomorrow. I need to check if it refreshes the session properly. 

Server was failing with access_token being expired. Looks like we need to use refresh_token. Which is confusing since we didn't have to use it in the other app we have (graypaper-reader). I made an issue in matrix-js-sdk to clarify what should be the actual implementation.
https://github.com/matrix-org/matrix-js-sdk/issues/4814

This solution uses username and password to obtain both access and refresh tokens. Then refresh token is used whenever session expires.
