### PR TITLE
Pass Supabase env vars to client build in deploy workflow

### DIFF
--- a/.github/workflows/deploy-client.yml
+++ b/.github/workflows/deploy-client.yml
@@ -38,6 +38,9 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build -w client
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
       - name: Setup Pages
         uses: actions/configure-pages@v6
       - name: Upload artifact

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,2 +1,6 @@
 # API URL for backend communication
 VITE_API_URL=http://localhost:3000
+
+# Supabase (required for auth features)
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=


### PR DESCRIPTION
## Summary
- Production GitHub Pages build was shipping with `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` inlined as `undefined`, causing `SupabaseProvider` to throw on missing `supabaseUrl`.
- Vite inlines `import.meta.env.VITE_*` at **build time** from `process.env`, so GitHub secrets must be explicitly mapped into the Build step's `env:` block — being set at the repo level alone isn't enough.
- Documented both vars in `client/.env.example` so the requirement is discoverable locally.

## Required secrets
The workflow reads `secrets.VITE_SUPABASE_URL` and `secrets.VITE_SUPABASE_ANON_KEY`. Make sure they exist under repo **Secrets** (not Variables), with those exact names.

## Test plan
- [ ] Verify both secrets exist at the repo level with the exact names above
- [ ] Trigger `Deploy: FE github pages` via `workflow_dispatch` (or cut a release)
- [ ] Load the deployed site and confirm no "missing supabaseUrl" error in the console
- [ ] Confirm auth features (sign-in flow) initialize without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured authentication provider credentials for deployment and development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->