### PR TITLE
Fix Supabase auth redirect under HashRouter

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes, useNavigate } from "react-router-dom";
+import { Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import "./App.css";
 import { AppsSidebar } from "@fluffylabs/shared-ui";
 import { AuthCallback, AuthFlow } from "@fluffylabs/shared-ui/supabase";
@@ -27,6 +27,24 @@ const queryClient = new QueryClient({
     },
   },
 });
+
+function AuthCallbackCatchAll({
+  onSuccess,
+  onError,
+}: {
+  onSuccess: () => void;
+  onError: () => void;
+}) {
+  const { pathname } = useLocation();
+  const params = new URLSearchParams(pathname.replace(/^\//, ""));
+  const hasError = params.has("error");
+  const hasToken = params.has("access_token");
+
+  if (hasError || hasToken) {
+    return <AuthCallback onSuccess={onSuccess} onError={onError} />;
+  }
+  return <div className="p-4">Page not found.</div>;
+}
 
 function App() {
   const isUsingEmbeddedViewer = useEmbeddedViewer().isVisible;
@@ -76,7 +94,7 @@ function App() {
                   element={
                     <AuthFlow
                       onSuccess={() => navigate("/")}
-                      redirectTo={`${window.location.origin}${window.location.pathname}#/auth/callback`}
+                      redirectTo={`${window.location.origin}${window.location.pathname}`}
                     />
                   }
                 />
@@ -90,6 +108,15 @@ function App() {
                   }
                 />
                 <Route path="/settings" element={<SettingsPage />} />
+                <Route
+                  path="*"
+                  element={
+                    <AuthCallbackCatchAll
+                      onSuccess={() => navigate("/")}
+                      onError={() => navigate("/login")}
+                    />
+                  }
+                />
               </Routes>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- The previous `redirectTo` included `#/auth/callback`, which caused Supabase to append tokens as `#/auth/callback#access_token=...`. supabase-js can't parse that shape, so sessions never established and expired links produced `No routes matched location "/error=access_denied&..."`.
- Drop the hash path from `redirectTo` so Supabase lands on a clean `#access_token=...` / `#error=...` hash, matching the format supabase-js's `detectSessionInUrl` expects.
- Add a catch-all `*` route that mounts `AuthCallback` when the hash looks like a Supabase auth response (has `error` or `access_token`), otherwise shows a minimal 404.

## Follow-up (shared-ui)
`AuthCallback` waits up to 5s for `SIGNED_IN` and otherwise shows a generic "Magic link expired" error. Ideally it should also read `error`/`error_description` from `window.location` and surface the real message — worth filing against `@fluffylabs/shared-ui`.

## Test plan
- [ ] Sign in with a valid magic link → lands on `/` and is signed in.
- [ ] Click an expired magic link → lands on `/login` (after ~5s) instead of an unmatched route.
- [ ] Navigate to an unknown path → shows the 404 message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Authentication callback detection improved to recognize both error and success states during user login processes
- Login redirect flow enhanced with better error handling, visibility, and overall state management capabilities
- Catch-all route handling added to properly direct unmatched requests to the authentication callback processor

<!-- end of auto-generated comment: release notes by coderabbit.ai -->