### PR TITLE
Guard CitationCard timestamp against invalid values

### DIFF
--- a/client/src/components/chat/CitationCard.tsx
+++ b/client/src/components/chat/CitationCard.tsx
@@ -9,6 +9,10 @@ interface CitationCardProps {
 }
 
 export function CitationCard({ citation, card }: CitationCardProps) {
+  // Validate the timestamp before calling toISOString() — an out-of-range or
+  // corrupted value would otherwise throw RangeError at render time.
+  const iso = toIsoOrNull(card?.timestamp);
+
   const header = (
     <div className="flex items-center gap-2 min-w-0 w-full">
       <span className="inline-flex items-center justify-center min-w-[1.5rem] h-5 px-1.5 rounded bg-brand-light text-brand-dark text-[11px] font-medium tabular-nums shrink-0">
@@ -24,12 +28,12 @@ export function CitationCard({ citation, card }: CitationCardProps) {
       <span className="flex-1 min-w-0 truncate font-medium text-foreground text-xs">
         {renderTitle(citation, card)}
       </span>
-      {card?.timestamp && (
+      {iso && (
         <time
-          dateTime={new Date(card.timestamp).toISOString()}
+          dateTime={iso}
           className="text-[10px] text-muted-foreground tabular-nums shrink-0"
         >
-          {formatDate(new Date(card.timestamp).toISOString())}
+          {formatDate(iso)}
         </time>
       )}
     </div>
@@ -60,6 +64,12 @@ export function CitationCard({ citation, card }: CitationCardProps) {
       <ResultCard header={header} content={content} footer={footer} />
     </div>
   );
+}
+
+function toIsoOrNull(ts: number | null | undefined): string | null {
+  if (ts === null || ts === undefined) return null;
+  const d = new Date(ts);
+  return Number.isFinite(d.getTime()) ? d.toISOString() : null;
 }
 
 function openLabel(type: SourceType): string {


### PR DESCRIPTION
## Summary

- Small follow-up to #233: wrap the two `new Date(card.timestamp).toISOString()` calls in `CitationCard.tsx` in a `toIsoOrNull` helper
- Helper validates the Date via `Number.isFinite(d.getTime())` and returns null on failure; the `<time>` element is skipped instead of throwing `RangeError`

## Why

Defensive — the current backend only emits valid epoch millis or `null`, but hydrating corrupted sessionStorage could produce an out-of-range timestamp (e.g., > 8.64e15 ms). The existing `if (card?.timestamp)` guard doesn't catch that case.

Raised by CodeRabbit review on #233.

## Test plan
- [x] `npm run qa` passes
- [x] Typecheck + tests clean (48/48)
- [ ] Manual: `/ask` still renders citation cards with valid timestamps unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp handling in citation cards to properly validate and display timestamps only when valid, preventing issues with invalid or missing dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->