### PR TITLE
Fix index jobs: write DATA_DIR to repo root so commits actually happen

### DIFF
--- a/.github/workflows/index-code.yml
+++ b/.github/workflows/index-code.yml
@@ -34,7 +34,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_INDEX_TOKEN }}
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          DATA_DIR: ./data
+          DATA_DIR: ${{ github.workspace }}/data
 
       - uses: ./.github/actions/commit-data
         with:

--- a/.github/workflows/index-discord.yml
+++ b/.github/workflows/index-discord.yml
@@ -34,7 +34,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_INDEX_TOKEN }}
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          DATA_DIR: ./data
+          DATA_DIR: ${{ github.workspace }}/data
 
       - uses: ./.github/actions/commit-data
         with:

--- a/.github/workflows/index-github.yml
+++ b/.github/workflows/index-github.yml
@@ -34,7 +34,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_INDEX_TOKEN }}
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          DATA_DIR: ./data
+          DATA_DIR: ${{ github.workspace }}/data
 
       - uses: ./.github/actions/commit-data
         with:

--- a/.github/workflows/index-graypaper.yml
+++ b/.github/workflows/index-graypaper.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run graypaper job
         run: npm exec tsx -w backend -- ./src/jobs/graypaperJob.ts
         env:
-          DATA_DIR: ./data
+          DATA_DIR: ${{ github.workspace }}/data
 
       - uses: ./.github/actions/commit-data
         with:

--- a/.github/workflows/index-matrix.yml
+++ b/.github/workflows/index-matrix.yml
@@ -34,7 +34,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_INDEX_TOKEN }}
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          DATA_DIR: ./data
+          DATA_DIR: ${{ github.workspace }}/data
 
       - uses: ./.github/actions/commit-data
         with:

--- a/.github/workflows/index-pages.yml
+++ b/.github/workflows/index-pages.yml
@@ -34,7 +34,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_INDEX_TOKEN }}
           DISCORD_TOKEN: ${{ secrets.DISCORD_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          DATA_DIR: ./data
+          DATA_DIR: ${{ github.workspace }}/data
 
       - uses: ./.github/actions/commit-data
         with:

--- a/backend/src/scripts/fetchCodeFiles.ts
+++ b/backend/src/scripts/fetchCodeFiles.ts
@@ -174,7 +174,7 @@ export async function fetchCodeFiles(opts: FetchCodeOptions): Promise<number> {
             chunk.endLine +
             ")",
           "",
-          "```" + (language ?? ""),
+          `\`\`\`${language ?? ""}`,
           chunk.text.endsWith("\n") ? chunk.text.slice(0, -1) : chunk.text,
           "```",
           "",


### PR DESCRIPTION
## Summary

- Index workflows have been silently broken since they were added — no `github-actions[bot]` commits have ever landed in `data/`.
- Root cause: each job runs `npm exec tsx -w backend -- ./src/jobs/<name>.ts`, and `-w backend` sets cwd to `backend/`. With `DATA_DIR: ./data`, the scripts wrote output to the ephemeral `backend/data/` on the runner, not the tracked `./data/` at the repo root. The `commit-data` composite action then ran `git add data/` at the repo root, found nothing staged, and exited success with no output.
- Fix: set `DATA_DIR: ${{ github.workspace }}/data` (absolute, cwd-proof) in all six `index-*.yml` workflows.
- Also fixes a pre-existing biome `useTemplate` warning in `fetchCodeFiles.ts:177` that surfaced in the `npm run qa` pre-push hook.

### Evidence the jobs were never committing
- `git log --author="github-actions" -- data/` → no results on main.
- Today's manual "Index: Code" run logged `Wrote 1583 code chunks from FluffyLabs/typeberry …` but the `commit-data` step completed in ~60 ms with zero stdout — consistent with `git diff --staged --quiet` returning clean because nothing was written to the checkout's `data/`.
- Verified locally: `npm exec -w backend -- node -e "console.log(process.cwd())"` prints `.../nashville/backend`.

### Heads-up on first run after merge
The first scheduled (or manually dispatched) run of each workflow will produce a large initial backfill commit for its data subtree (code, discord, github, graypaper, matrix, pages). Expect noisy `data/` churn on that first pass.

## Test plan

- [ ] Merge, then manually dispatch `Index: Code` and confirm an `index: update code files` commit appears on `main` with files under `data/code/…`.
- [ ] Manually dispatch one other index workflow (e.g. `Index: Graypaper`) and confirm the equivalent commit lands.
- [ ] Check next scheduled runs (Discord @02:00 UTC, GitHub @04:00 UTC, Graypaper @05:00 UTC, Matrix @06:00 UTC) produce commits, not silent no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations across all indexing jobs to use absolute paths for data directory resolution, improving path reliability in automated environments.
  * Refactored markdown code fence generation to enhance code formatting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->