### PR TITLE
Use default GHA token to commit indexed data

### DIFF
--- a/.github/workflows/index-code.yml
+++ b/.github/workflows/index-code.yml
@@ -16,8 +16,6 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.GH_INDEX_TOKEN }}
 
       - name: Setup Node.js with cache
         uses: actions/setup-node@v6

--- a/.github/workflows/index-discord.yml
+++ b/.github/workflows/index-discord.yml
@@ -16,8 +16,6 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.GH_INDEX_TOKEN }}
 
       - name: Setup Node.js with cache
         uses: actions/setup-node@v6

--- a/.github/workflows/index-github.yml
+++ b/.github/workflows/index-github.yml
@@ -16,8 +16,6 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.GH_INDEX_TOKEN }}
 
       - name: Setup Node.js with cache
         uses: actions/setup-node@v6

--- a/.github/workflows/index-graypaper.yml
+++ b/.github/workflows/index-graypaper.yml
@@ -16,8 +16,6 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.GH_INDEX_TOKEN }}
 
       - name: Setup Node.js with cache
         uses: actions/setup-node@v6

--- a/.github/workflows/index-matrix.yml
+++ b/.github/workflows/index-matrix.yml
@@ -16,8 +16,6 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.GH_INDEX_TOKEN }}
 
       - name: Setup Node.js with cache
         uses: actions/setup-node@v6

--- a/.github/workflows/index-pages.yml
+++ b/.github/workflows/index-pages.yml
@@ -16,8 +16,6 @@ jobs:
     environment: production
     steps:
       - uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.GH_INDEX_TOKEN }}
 
       - name: Setup Node.js with cache
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- `Index: GitHub` job was failing at push time with `Permission to FluffyLabs/jam-search.git denied to mikemagix`. Root cause: `actions/checkout` in all `index-*.yml` workflows persisted `GH_INDEX_TOKEN` (a PAT owned by `mikemagix`, scoped for external-repo API access) as the git credential used by the later `git push` in `.github/actions/commit-data`.
- Dropped the `token:` override from `actions/checkout` in all six `index-*` workflows. Checkout now uses the built-in `GITHUB_TOKEN`, which already has `contents: write` from the workflow-level `permissions:` block, so the commit-data push succeeds.
- `GH_INDEX_TOKEN` is still passed as `GITHUB_TOKEN` env var into the job scripts that need it for cross-repo API access.

## Caveat
Pushes made by the default `GITHUB_TOKEN` do not trigger other workflows. Checked `deploy-backend.yml` and `deploy-client.yml` — both run on `release` / `workflow_dispatch`, not `push`, so nothing downstream is affected.

## Test plan
- [ ] Manually dispatch `Index: GitHub` and verify the commit + push step succeeds
- [ ] Spot-check one other index workflow (e.g. `Index: Pages`) via manual dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication configuration in continuous integration workflows across indexing pipelines to streamline checkout procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->