### PR TITLE
client: show config error when Supabase env vars are missing

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -11,12 +11,6 @@ import { EmbeddedViewerProvider } from "./providers/EmbeddedResultsContext.tsx";
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-if (!supabaseUrl || !supabaseAnonKey) {
-  console.warn(
-    "Supabase environment variables not configured. Auth features will be disabled."
-  );
-}
-
 // Initialize dark mode from system preference (toggled via sidebar)
 const darkModeQuery = window.matchMedia("(prefers-color-scheme: dark)");
 document.documentElement.classList.toggle("dark", darkModeQuery.matches);
@@ -28,6 +22,33 @@ const root = document.getElementById("root");
 if (root === null) {
   throw new Error("Root not found!");
 }
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  const missing = [
+    !supabaseUrl && "VITE_SUPABASE_URL",
+    !supabaseAnonKey && "VITE_SUPABASE_ANON_KEY",
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  root.innerHTML = `
+    <div style="min-height:100vh;display:flex;align-items:center;justify-content:center;padding:2rem;font-family:system-ui,-apple-system,sans-serif;background:#fff;color:#111;">
+      <style>@media (prefers-color-scheme: dark){.cfg-err{background:#0a0a0a !important;color:#fafafa !important;}.cfg-err pre{background:#1a1a1a !important;color:#fafafa !important;}.cfg-err code{background:#1a1a1a !important;}}</style>
+      <div class="cfg-err" style="max-width:640px;border:1px solid #e11d48;border-radius:8px;padding:1.5rem 2rem;background:#fff;color:#111;">
+        <h1 style="margin:0 0 0.75rem;font-size:1.5rem;color:#e11d48;">Configuration error</h1>
+        <p style="margin:0 0 1rem;line-height:1.5;">
+          Missing required environment variable${missing.includes(",") ? "s" : ""}:
+        </p>
+        <pre style="margin:0 0 1rem;padding:0.75rem 1rem;background:#f5f5f5;border-radius:4px;overflow-x:auto;font-size:0.875rem;">${missing}</pre>
+        <p style="margin:0;line-height:1.5;">
+          Copy <code style="padding:0.1rem 0.35rem;background:#f5f5f5;border-radius:3px;font-size:0.875rem;">client/.env.example</code> to <code style="padding:0.1rem 0.35rem;background:#f5f5f5;border-radius:3px;font-size:0.875rem;">client/.env</code> and fill in your Supabase project URL and anon key, then restart the dev server.
+        </p>
+      </div>
+    </div>
+  `;
+  throw new Error(`Missing required environment variables: ${missing}`);
+}
+
 createRoot(root).render(
   <StrictMode>
     <HashRouter>

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -8,8 +8,8 @@ import { HashRouter } from "react-router-dom";
 import App from "./App.tsx";
 import { EmbeddedViewerProvider } from "./providers/EmbeddedResultsContext.tsx";
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL?.trim();
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY?.trim();
 
 // Initialize dark mode from system preference (toggled via sidebar)
 const darkModeQuery = window.matchMedia("(prefers-color-scheme: dark)");


### PR DESCRIPTION
## Summary
- When `VITE_SUPABASE_URL` or `VITE_SUPABASE_ANON_KEY` is missing, the dev server previously rendered a blank white page (the `SupabaseProvider` crashed silently during init).
- Now we render a styled error card naming the missing variable(s) and pointing to `client/.env.example`, so the failure mode is obvious.
- Dark-mode aware via `prefers-color-scheme`. Uses inline styles so it doesn't depend on the React tree mounting.

## Test plan
- [ ] Run dev server with both env vars unset → confirm error card renders (not white screen).
- [ ] Run dev server with only `VITE_SUPABASE_URL` unset → confirm only that variable is listed.
- [ ] Run dev server with both env vars set → confirm app loads normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for missing Supabase configuration: the app now stops startup and displays a clear in-page error that lists which environment variables are missing and instructs how to populate them (e.g., copy the example env file). This prevents the app from running with an incomplete setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->