### PR TITLE
Redesign ask page: reclaim space, fix dark-mode contrast

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -50,6 +50,10 @@ function AuthCallbackCatchAll({
 function App() {
   const isUsingEmbeddedViewer = useEmbeddedViewer().isVisible;
   const navigate = useNavigate();
+  const { pathname } = useLocation();
+  // /ask manages its own scroll/padding so the section/aside border can
+  // span the full available height.
+  const fullBleed = pathname === "/ask";
 
   return (
     <QueryClientProvider client={queryClient}>
@@ -73,7 +77,7 @@ function App() {
           >
             <EmbeddedViewer />
             <div
-              className={cn("p-4 h-full overflow-y-auto", {
+              className={cn("h-full", fullBleed ? "" : "p-4 overflow-y-auto", {
                 invisible: isUsingEmbeddedViewer,
               })}
             >

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -71,9 +71,12 @@ function App() {
           </div>
 
           <div
-            className={cn("w-full bg-background h-[calc(100dvh-77px)]", {
-              relative: isUsingEmbeddedViewer,
-            })}
+            className={cn(
+              "w-full bg-background h-[calc(100dvh-77px)] border-l-1 border-l-white dark:border-l-1 dark:border-l-[#353535]",
+              {
+                relative: isUsingEmbeddedViewer,
+              }
+            )}
           >
             <EmbeddedViewer />
             <div

--- a/client/src/components/chat/ChatInput.tsx
+++ b/client/src/components/chat/ChatInput.tsx
@@ -94,7 +94,6 @@ export function ChatInput({
             onClick={submit}
             disabled={!ready}
             size="sm"
-            variant={ready ? "default" : "ghost"}
           >
             Ask
           </Button>

--- a/client/src/components/chat/ChatInput.tsx
+++ b/client/src/components/chat/ChatInput.tsx
@@ -2,12 +2,15 @@ import { type KeyboardEvent, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
+import { ModelPicker } from "./ModelPicker";
 
 interface ChatInputProps {
   initialValue?: string;
   placeholder?: string;
   disabled?: boolean;
   onSubmit: (text: string) => void;
+  model: string;
+  onModelChange: (modelId: string) => void;
 }
 
 export function ChatInput({
@@ -15,18 +18,18 @@ export function ChatInput({
   placeholder = "Ask a follow-up…",
   disabled,
   onSubmit,
+  model,
+  onModelChange,
 }: ChatInputProps) {
   const [value, setValue] = useState(initialValue);
   const [prevInitial, setPrevInitial] = useState(initialValue);
   const taRef = useRef<HTMLTextAreaElement>(null);
 
-  // Sync with external changes to initialValue (e.g. navigating with ?q=…)
   if (initialValue !== prevInitial) {
     setPrevInitial(initialValue);
     setValue(initialValue);
   }
 
-  // Auto-grow up to a reasonable max
   // biome-ignore lint/correctness/useExhaustiveDependencies: value is the trigger
   useEffect(() => {
     const el = taRef.current;
@@ -43,8 +46,6 @@ export function ChatInput({
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    // Don't submit while an IME is composing (Enter confirms the composition
-    // in CJK languages — it shouldn't also submit the form).
     if (e.nativeEvent.isComposing) return;
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
@@ -76,8 +77,8 @@ export function ChatInput({
           "text-[15px] leading-6 px-4 py-3"
         )}
       />
-      <div className="flex items-center justify-between px-3 py-2 border-t border-border/60">
-        <span className="text-[11px] text-muted-foreground">
+      <div className="flex items-center justify-between gap-2 px-3 py-2 border-t border-border/60">
+        <span className="hidden sm:inline text-[11px] text-muted-foreground">
           <kbd className="px-1 py-0.5 rounded bg-muted text-muted-foreground text-[10px]">
             ⏎
           </kbd>{" "}
@@ -87,14 +88,17 @@ export function ChatInput({
           </kbd>{" "}
           for newline
         </span>
-        <Button
-          onClick={submit}
-          disabled={!ready}
-          size="sm"
-          variant={ready ? "default" : "ghost"}
-        >
-          Ask
-        </Button>
+        <div className="flex items-center gap-2 ml-auto">
+          <ModelPicker value={model} onChange={onModelChange} />
+          <Button
+            onClick={submit}
+            disabled={!ready}
+            size="sm"
+            variant={ready ? "default" : "ghost"}
+          >
+            Ask
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/client/src/components/chat/ChatInput.tsx
+++ b/client/src/components/chat/ChatInput.tsx
@@ -90,11 +90,7 @@ export function ChatInput({
         </span>
         <div className="flex items-center gap-2 ml-auto">
           <ModelPicker value={model} onChange={onModelChange} />
-          <Button
-            onClick={submit}
-            disabled={!ready}
-            size="sm"
-          >
+          <Button onClick={submit} disabled={!ready} size="sm">
             Ask
           </Button>
         </div>

--- a/client/src/components/chat/Message.tsx
+++ b/client/src/components/chat/Message.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
 import type { AssistantPart, ChatMessage, TextPart } from "@/lib/askTypes";
 import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
 import { Markdown } from "./Markdown";
 import { ToolStep } from "./ToolStep";
 

--- a/client/src/components/chat/Message.tsx
+++ b/client/src/components/chat/Message.tsx
@@ -1,5 +1,7 @@
+import { useNavigate } from "react-router-dom";
 import type { AssistantPart, ChatMessage, TextPart } from "@/lib/askTypes";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import { Markdown } from "./Markdown";
 import { ToolStep } from "./ToolStep";
 
@@ -8,6 +10,8 @@ interface MessageProps {
 }
 
 export function Message({ message }: MessageProps) {
+  const navigate = useNavigate();
+
   if (message.role === "user") {
     return (
       <div className="flex justify-end">
@@ -47,8 +51,18 @@ export function Message({ message }: MessageProps) {
       )}
 
       {message.error && (
-        <div className="rounded-md border border-destructive/40 bg-destructive/10 text-destructive text-sm px-3 py-2">
-          {message.error}
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 text-destructive text-sm px-3 py-2 flex items-start justify-between gap-3">
+          <span className="flex-1">{message.error}</span>
+          {message.errorKind === "missingApiKey" && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="shrink-0 border-destructive/40 text-destructive hover:bg-destructive/20"
+              onClick={() => navigate("/settings")}
+            >
+              Go to Settings
+            </Button>
+          )}
         </div>
       )}
     </div>

--- a/client/src/components/chat/ModelPicker.tsx
+++ b/client/src/components/chat/ModelPicker.tsx
@@ -60,10 +60,11 @@ export function ModelPicker({ value, onChange }: ModelPickerProps) {
                 onSelect={() => onChange(m.id)}
                 className={cn(
                   "cursor-pointer",
-                  m.id === value && "font-medium text-brand-dark"
+                  m.id === value &&
+                    "font-medium text-brand-dark dark:text-brand"
                 )}
               >
-                <span className="w-3 text-brand-dark">
+                <span className="w-3 text-brand-dark dark:text-brand">
                   {m.id === value ? "✓" : ""}
                 </span>
                 <span className="flex-1">{m.label}</span>

--- a/client/src/components/ui/button-variants.tsx
+++ b/client/src/components/ui/button-variants.tsx
@@ -14,7 +14,8 @@ export const buttonVariants = cva(
           "border border-input border-brand-dark text-brand-dark dark:border-brand dark:text-brand hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-foreground hover:text-background dark:hover:bg-brand dark:hover:text-background",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        ghost:
+          "text-foreground hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/client/src/components/ui/button-variants.tsx
+++ b/client/src/components/ui/button-variants.tsx
@@ -14,8 +14,7 @@ export const buttonVariants = cva(
           "border border-input border-brand-dark text-brand-dark dark:border-brand dark:text-brand hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-foreground hover:text-background dark:hover:bg-brand dark:hover:text-background",
-        ghost:
-          "text-foreground hover:bg-accent hover:text-accent-foreground",
+        ghost: "text-foreground hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {

--- a/client/src/components/ui/button-variants.tsx
+++ b/client/src/components/ui/button-variants.tsx
@@ -9,7 +9,7 @@ export const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background text-foreground hover:bg-accent hover:text-accent-foreground",
         outlineBrand:
           "border border-input border-brand-dark text-brand-dark dark:border-brand dark:text-brand hover:bg-accent hover:text-accent-foreground",
         secondary:

--- a/client/src/components/ui/textarea.tsx
+++ b/client/src/components/ui/textarea.tsx
@@ -11,7 +11,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "min-h-[80px] w-full rounded-md border border-input bg-background text-foreground px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -63,8 +63,8 @@
   --secondary-foreground: hsl(0 0% 52%);
 
   --card-foreground: var(--title-foreground);
-  --popover: hsl(190 84% 4.9%);
-  --popover-foreground: hsl(210 40% 98%);
+  --popover: var(--card);
+  --popover-foreground: var(--foreground);
   --primary: hsl(175 80% 65%);
   --primary-foreground: hsl(190 47.4% 11.2%);
   --muted: hsl(0 0% 0%);

--- a/client/src/lib/__tests__/askReducer.test.ts
+++ b/client/src/lib/__tests__/askReducer.test.ts
@@ -145,6 +145,29 @@ describe("askReducer", () => {
     expect(last.error).toBe("boom");
   });
 
+  it("setError stores errorKind when provided", () => {
+    let s = freshAssistant();
+    s = askReducer(s, {
+      type: "setError",
+      message: "No OpenRouter API key found. Add one in Settings to begin.",
+      kind: "missingApiKey",
+    });
+    const last = lastAssistant(s);
+    expect(last.error).toBe(
+      "No OpenRouter API key found. Add one in Settings to begin."
+    );
+    expect(last.errorKind).toBe("missingApiKey");
+    expect(last.isStreaming).toBe(false);
+  });
+
+  it("setError leaves errorKind undefined when kind is omitted", () => {
+    let s = freshAssistant();
+    s = askReducer(s, { type: "setError", message: "boom" });
+    const last = lastAssistant(s);
+    expect(last.error).toBe("boom");
+    expect(last.errorKind).toBeUndefined();
+  });
+
   it("setModel updates only the model field", () => {
     const s = askReducer(initialState, {
       type: "setModel",

--- a/client/src/lib/askReducer.ts
+++ b/client/src/lib/askReducer.ts
@@ -4,6 +4,7 @@ import type {
   AssistantPart,
   ChatMessage,
   CitationCardData,
+  ErrorKind,
   SourceType,
   TextPart,
   ToolPart,
@@ -34,7 +35,7 @@ export type AskAction =
       sourceType: SourceType;
     }
   | { type: "finishStreaming" }
-  | { type: "setError"; message: string }
+  | { type: "setError"; message: string; kind?: ErrorKind }
   | { type: "setModel"; model: string }
   | { type: "reset" }
   | { type: "hydrate"; state: AskConversationState };
@@ -238,6 +239,7 @@ export function askReducer(
           ...m,
           isStreaming: false,
           error: action.message,
+          errorKind: action.kind,
         })),
       };
 

--- a/client/src/lib/askTypes.ts
+++ b/client/src/lib/askTypes.ts
@@ -1,5 +1,7 @@
 export type SourceType = "graypaper" | "discord" | "matrix" | "page";
 
+export type ErrorKind = "missingApiKey";
+
 /** Raw agent events streamed from the backend `/ask` SSE endpoint. */
 export type AgentEvent =
   | { type: "tool_call"; name: string; args: unknown }
@@ -68,6 +70,7 @@ export interface AssistantMessage {
   parts: AssistantPart[];
   citations: Citation[];
   error?: string;
+  errorKind?: ErrorKind;
   isStreaming: boolean;
 }
 

--- a/client/src/pages/ask.tsx
+++ b/client/src/pages/ask.tsx
@@ -5,7 +5,6 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { ChatInput } from "@/components/chat/ChatInput";
 import { CitationsPanel } from "@/components/chat/CitationsPanel";
 import { Message } from "@/components/chat/Message";
-import { ModelPicker } from "@/components/chat/ModelPicker";
 import { Button } from "@/components/ui/button";
 import { useAskConversation } from "@/hooks/useAskConversation";
 import { askStream } from "@/lib/askClient";
@@ -22,15 +21,13 @@ export function AskPage() {
   const autoSubmit = searchParams.get("autoSubmit") === "1";
 
   const { state, dispatch } = useAskConversation();
-  // Auth-session restore is async on page refresh. useUserData short-circuits
-  // to { isLoading: false, data: null } while `user` is null, so gating on
-  // keyLoading alone is a false-negative — we must also wait for the session.
   const { isLoading: sessionLoading } = useSession();
   const { data: keyData, isLoading: keyLoading } = useUserData(
     "openrouter-api-key",
     { appScoped: true }
   );
   const isReady = !sessionLoading && !keyLoading;
+  const hasApiKey = typeof keyData === "string" && keyData.trim() !== "";
 
   const streamHandleRef = useRef<{ abort: () => void } | null>(null);
   const hasAutoSubmittedRef = useRef(false);
@@ -39,8 +36,7 @@ export function AskPage() {
   const send = useCallback(
     (text: string, options?: { startFresh?: boolean }) => {
       if (!isReady) return;
-      const apiKey =
-        typeof keyData === "string" && keyData.trim() !== "" ? keyData : null;
+      const apiKey = hasApiKey ? (keyData as string) : null;
       if (!apiKey) {
         if (options?.startFresh) dispatch({ type: "reset" });
         dispatch({ type: "sendUserMessage", text });
@@ -55,8 +51,6 @@ export function AskPage() {
       if (options?.startFresh) dispatch({ type: "reset" });
       dispatch({ type: "sendUserMessage", text });
 
-      // When starting fresh, the prior history we send to the backend is empty;
-      // closure-captured state.messages is stale right after dispatch(reset).
       const priorMessages = options?.startFresh ? [] : state.messages;
       const nextMessages = [
         ...priorMessages,
@@ -107,15 +101,9 @@ export function AskPage() {
         }
       );
     },
-    [isReady, keyData, dispatch, state.messages, state.model]
+    [isReady, hasApiKey, keyData, dispatch, state.messages, state.model]
   );
 
-  // Auto-submit once if ?q is set and ?autoSubmit=1. Skip the re-run if the
-  // hydrated sessionStorage conversation already ends with a completed answer
-  // for this same prompt. Either way, strip ?autoSubmit=1 from the URL so a
-  // refresh doesn't re-trigger submission. The hasAutoSubmittedRef guard keeps
-  // this idempotent even though the effect re-runs as deps like state.messages
-  // change during streaming; re-runs after the first fire hit the early return.
   useEffect(() => {
     if (!autoSubmit || !initialQuery || hasAutoSubmittedRef.current) return;
     if (!isReady) return;
@@ -161,7 +149,6 @@ export function AskPage() {
     };
   }, []);
 
-  // Auto-scroll as messages stream in.
   // biome-ignore lint/correctness/useExhaustiveDependencies: state.messages is the trigger
   useEffect(() => {
     const el = scrollRef.current;
@@ -176,66 +163,51 @@ export function AskPage() {
   const streaming = lastAssistant?.isStreaming === true;
   const isEmpty = state.messages.length === 0;
 
+  const handleNewChat = () => {
+    streamHandleRef.current?.abort();
+    streamHandleRef.current = null;
+    dispatch({ type: "reset" });
+  };
+
   return (
     <div className="flex flex-col h-full bg-background">
-      {/* Header */}
-      <header className="flex items-center justify-between px-6 py-4 border-b border-border bg-card/30">
-        <div className="flex items-center gap-4">
-          <div className="flex items-center gap-2">
-            <Sparkles className="h-4 w-4 text-brand-dark" />
-            <h1 className="text-base font-semibold text-foreground">Ask AI</h1>
-          </div>
-          <div className="h-4 w-px bg-border" />
-          <ModelPicker
-            value={state.model}
-            onChange={(m) => dispatch({ type: "setModel", model: m })}
-          />
-        </div>
-        <div className="flex items-center gap-1">
-          {state.messages.length > 0 && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => {
-                streamHandleRef.current?.abort();
-                streamHandleRef.current = null;
-                dispatch({ type: "reset" });
-              }}
-            >
-              New chat
-            </Button>
-          )}
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => navigate("/settings")}
-          >
-            Settings
-          </Button>
-        </div>
-      </header>
-
-      {/* Body */}
       <div className="flex-1 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_22rem] overflow-hidden">
-        {/* Conversation column */}
         <section className="flex flex-col overflow-hidden">
           <div ref={scrollRef} className="flex-1 overflow-y-auto">
             {isEmpty ? (
-              <EmptyState />
+              <EmptyState
+                showApiKeyCta={isReady && !hasApiKey}
+                onOpenSettings={() => navigate("/settings")}
+              />
             ) : (
-              <div className="max-w-[44rem] mx-auto px-6 py-8 flex flex-col gap-6">
-                {state.messages.map((m) => (
-                  <Message key={m.id} message={m} />
-                ))}
-              </div>
+              <>
+                <div className="sticky top-0 z-10 backdrop-blur bg-background/80 border-b border-border/60">
+                  <div className="max-w-[52rem] mx-auto px-6 py-2 flex justify-end">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleNewChat}
+                    >
+                      New chat
+                    </Button>
+                  </div>
+                </div>
+                <div className="max-w-[52rem] mx-auto px-6 py-8 flex flex-col gap-6">
+                  {state.messages.map((m) => (
+                    <Message key={m.id} message={m} />
+                  ))}
+                </div>
+              </>
             )}
           </div>
 
-          <div className="max-w-[44rem] w-full mx-auto px-6 pb-6">
+          <div className="max-w-[52rem] w-full mx-auto px-6 pb-6">
             <ChatInput
               initialValue={autoSubmit ? "" : initialQuery}
               disabled={streaming || !isReady}
               onSubmit={send}
+              model={state.model}
+              onModelChange={(m) => dispatch({ type: "setModel", model: m })}
               placeholder={
                 isEmpty
                   ? "What would you like to know about JAM?"
@@ -245,7 +217,6 @@ export function AskPage() {
           </div>
         </section>
 
-        {/* Sources panel */}
         <aside className="hidden lg:block border-l border-border overflow-y-auto bg-card/20 px-5 py-6">
           <CitationsPanel assistant={lastAssistant} cards={state.cards} />
         </aside>
@@ -254,7 +225,12 @@ export function AskPage() {
   );
 }
 
-function EmptyState() {
+interface EmptyStateProps {
+  showApiKeyCta: boolean;
+  onOpenSettings: () => void;
+}
+
+function EmptyState({ showApiKeyCta, onOpenSettings }: EmptyStateProps) {
   return (
     <div className="max-w-[36rem] mx-auto px-6 pt-16 pb-8 text-center">
       <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-brand-light text-brand-dark mb-5">
@@ -267,6 +243,13 @@ function EmptyState() {
         An agent will search the Graypaper, Discord and Matrix discussions, and
         indexed pages, then answer with cited sources.
       </p>
+      {showApiKeyCta && (
+        <div className="mt-6">
+          <Button variant="outline" onClick={onOpenSettings}>
+            Configure OpenRouter API key
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/pages/ask.tsx
+++ b/client/src/pages/ask.tsx
@@ -233,7 +233,7 @@ interface EmptyStateProps {
 function EmptyState({ showApiKeyCta, onOpenSettings }: EmptyStateProps) {
   return (
     <div className="max-w-[36rem] mx-auto px-6 pt-16 pb-8 text-center">
-      <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-brand-light text-brand-dark mb-5">
+      <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-brand-light text-brand-dark dark:bg-brand-dark dark:text-brand mb-5">
         <Sparkles className="h-5 w-5" />
       </div>
       <h2 className="text-2xl font-semibold text-foreground mb-3">

--- a/client/src/pages/ask.tsx
+++ b/client/src/pages/ask.tsx
@@ -172,7 +172,7 @@ export function AskPage() {
   return (
     <div className="flex flex-col h-full bg-background">
       <div className="flex-1 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_22rem] overflow-hidden">
-        <section className="flex flex-col overflow-hidden">
+        <section className="flex flex-col overflow-hidden border-r-1 border-r-[#D4D4D4] dark:border-r-1 dark:border-r-[#181818]">
           <div ref={scrollRef} className="flex-1 overflow-y-auto">
             {isEmpty ? (
               <EmptyState
@@ -217,7 +217,7 @@ export function AskPage() {
           </div>
         </section>
 
-        <aside className="hidden lg:block border-l border-border overflow-y-auto bg-card/20 px-5 py-6">
+        <aside className="hidden lg:block border-l-1 border-l-white dark:border-l-1 dark:border-l-[#353535] overflow-y-auto bg-card/20 px-5 py-6">
           <CitationsPanel assistant={lastAssistant} cards={state.cards} />
         </aside>
       </div>

--- a/client/src/pages/ask.tsx
+++ b/client/src/pages/ask.tsx
@@ -47,6 +47,7 @@ export function AskPage() {
         dispatch({
           type: "setError",
           message: "No OpenRouter API key found. Add one in Settings to begin.",
+          kind: "missingApiKey",
         });
         return;
       }

--- a/client/src/pages/ask.tsx
+++ b/client/src/pages/ask.tsx
@@ -183,11 +183,7 @@ export function AskPage() {
               <>
                 <div className="sticky top-0 z-10 backdrop-blur bg-background/80 border-b border-border/60">
                   <div className="max-w-[52rem] mx-auto px-6 py-2 flex justify-end">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={handleNewChat}
-                    >
+                    <Button variant="ghost" size="sm" onClick={handleNewChat}>
                       New chat
                     </Button>
                   </div>

--- a/client/src/pages/ask.tsx
+++ b/client/src/pages/ask.tsx
@@ -27,7 +27,8 @@ export function AskPage() {
     { appScoped: true }
   );
   const isReady = !sessionLoading && !keyLoading;
-  const hasApiKey = typeof keyData === "string" && keyData.trim() !== "";
+  const trimmedApiKey = typeof keyData === "string" ? keyData.trim() : "";
+  const hasApiKey = trimmedApiKey !== "";
 
   const streamHandleRef = useRef<{ abort: () => void } | null>(null);
   const hasAutoSubmittedRef = useRef(false);
@@ -36,7 +37,7 @@ export function AskPage() {
   const send = useCallback(
     (text: string, options?: { startFresh?: boolean }) => {
       if (!isReady) return;
-      const apiKey = hasApiKey ? (keyData as string) : null;
+      const apiKey = hasApiKey ? trimmedApiKey : null;
       if (!apiKey) {
         if (options?.startFresh) dispatch({ type: "reset" });
         dispatch({ type: "sendUserMessage", text });
@@ -101,7 +102,7 @@ export function AskPage() {
         }
       );
     },
-    [isReady, hasApiKey, keyData, dispatch, state.messages, state.model]
+    [isReady, hasApiKey, trimmedApiKey, dispatch, state.messages, state.model]
   );
 
   useEffect(() => {

--- a/docs/superpowers/plans/2026-04-23-ask-page-redesign.md
+++ b/docs/superpowers/plans/2026-04-23-ask-page-redesign.md
@@ -1,0 +1,730 @@
+# Ask Page Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reclaim vertical space on the ask page by removing the header bar, relocating controls, and trimming Settings to a conditional shortcut.
+
+**Architecture:** UI-only refactor of `client/src/pages/ask.tsx` and a handful of chat components. Adds an `errorKind` discriminator to the reducer's error payload so missing-API-key errors can render a Settings call-to-action without string-matching.
+
+**Tech Stack:** React 19, TypeScript, Tailwind v4, Vitest, react-router-dom v7. Lucide icons already in use.
+
+---
+
+## File Structure
+
+**Modified:**
+- `client/src/lib/askTypes.ts` — add optional `errorKind` field to `AssistantMessage`.
+- `client/src/lib/askReducer.ts` — `setError` action accepts optional `kind`; reducer stores it on the last assistant.
+- `client/src/lib/__tests__/askReducer.test.ts` — test coverage for `errorKind`.
+- `client/src/pages/ask.tsx` — remove header, lift `hasApiKey`, pass model/handlers to ChatInput, render sticky "New chat", dispatch missing-key error with `kind: "missingApiKey"`, widen column, show conditional Settings link in empty state.
+- `client/src/components/chat/ChatInput.tsx` — accept `model` + `onModelChange` props; render `ModelPicker` next to the Ask button.
+- `client/src/components/chat/Message.tsx` — when `message.errorKind === "missingApiKey"`, render a "Go to Settings" button inside the error block.
+
+**Not touched:** backend, routing config, `CitationsPanel`, `Markdown`, `ToolStep`, `ModelPicker` itself.
+
+---
+
+## Task 1: Add `errorKind` to types and reducer
+
+**Files:**
+- Modify: `client/src/lib/askTypes.ts`
+- Modify: `client/src/lib/askReducer.ts`
+- Test: `client/src/lib/__tests__/askReducer.test.ts`
+
+- [ ] **Step 1: Extend `AssistantMessage` type**
+
+Edit `client/src/lib/askTypes.ts` — add `errorKind` next to the existing `error` field:
+
+```ts
+export type ErrorKind = "missingApiKey";
+
+export interface AssistantMessage {
+  id: string;
+  role: "assistant";
+  parts: AssistantPart[];
+  citations: Citation[];
+  error?: string;
+  errorKind?: ErrorKind;
+  isStreaming: boolean;
+}
+```
+
+- [ ] **Step 2: Extend the `setError` action**
+
+Edit `client/src/lib/askReducer.ts` — import the new type and update the action + reducer:
+
+```ts
+import type {
+  AskConversationState,
+  AssistantMessage,
+  AssistantPart,
+  ChatMessage,
+  CitationCardData,
+  ErrorKind,
+  SourceType,
+  TextPart,
+  ToolPart,
+  UserMessage,
+} from "./askTypes";
+```
+
+Update the `AskAction` union:
+
+```ts
+  | { type: "setError"; message: string; kind?: ErrorKind }
+```
+
+Update the reducer case:
+
+```ts
+    case "setError":
+      return {
+        ...state,
+        messages: mapLastAssistant(state.messages, (m) => ({
+          ...m,
+          isStreaming: false,
+          error: action.message,
+          errorKind: action.kind,
+        })),
+      };
+```
+
+- [ ] **Step 3: Write the failing test**
+
+Append to `client/src/lib/__tests__/askReducer.test.ts` inside the existing `describe` block (before the closing brace):
+
+```ts
+  it("setError stores errorKind when provided", () => {
+    let s = freshAssistant();
+    s = askReducer(s, {
+      type: "setError",
+      message: "No OpenRouter API key found. Add one in Settings to begin.",
+      kind: "missingApiKey",
+    });
+    const last = lastAssistant(s);
+    expect(last.error).toBe(
+      "No OpenRouter API key found. Add one in Settings to begin."
+    );
+    expect(last.errorKind).toBe("missingApiKey");
+    expect(last.isStreaming).toBe(false);
+  });
+
+  it("setError leaves errorKind undefined when kind is omitted", () => {
+    let s = freshAssistant();
+    s = askReducer(s, { type: "setError", message: "boom" });
+    const last = lastAssistant(s);
+    expect(last.error).toBe("boom");
+    expect(last.errorKind).toBeUndefined();
+  });
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd client && npm test -- askReducer
+```
+
+Expected: both new tests pass alongside existing ones.
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+cd client && npm run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/lib/askTypes.ts client/src/lib/askReducer.ts client/src/lib/__tests__/askReducer.test.ts
+git commit -m "ask: add errorKind discriminator to assistant errors"
+```
+
+---
+
+## Task 2: Render Settings button for missing-key error in `Message.tsx`
+
+**Files:**
+- Modify: `client/src/components/chat/Message.tsx`
+
+- [ ] **Step 1: Add a Settings CTA to the error block**
+
+Replace the existing error block (lines 49–53) with a conditional layout that shows a "Go to Settings" button when `errorKind === "missingApiKey"`. Add `useNavigate` import.
+
+Replace the imports at the top of `client/src/components/chat/Message.tsx`:
+
+```ts
+import { useNavigate } from "react-router-dom";
+import type { AssistantPart, ChatMessage, TextPart } from "@/lib/askTypes";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Markdown } from "./Markdown";
+import { ToolStep } from "./ToolStep";
+```
+
+Inside `Message`, declare the navigate hook at the top (before the `user` branch so it's unconditional):
+
+```ts
+export function Message({ message }: MessageProps) {
+  const navigate = useNavigate();
+
+  if (message.role === "user") {
+    // ...unchanged
+```
+
+Replace the error block with:
+
+```tsx
+      {message.error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/10 text-destructive text-sm px-3 py-2 flex items-start justify-between gap-3">
+          <span className="flex-1">{message.error}</span>
+          {message.errorKind === "missingApiKey" && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="shrink-0 border-destructive/40 text-destructive hover:bg-destructive/20"
+              onClick={() => navigate("/settings")}
+            >
+              Go to Settings
+            </Button>
+          )}
+        </div>
+      )}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd client && npm run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Lint**
+
+```bash
+cd client && npm run lint
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/components/chat/Message.tsx
+git commit -m "ask: surface Settings CTA on missing-API-key errors"
+```
+
+---
+
+## Task 3: Dispatch `missingApiKey` kind from `AskPage`
+
+**Files:**
+- Modify: `client/src/pages/ask.tsx`
+
+- [ ] **Step 1: Pass the error kind**
+
+In `client/src/pages/ask.tsx`, inside `send` (around line 47), change:
+
+```ts
+        dispatch({
+          type: "setError",
+          message: "No OpenRouter API key found. Add one in Settings to begin.",
+        });
+```
+
+to:
+
+```ts
+        dispatch({
+          type: "setError",
+          message: "No OpenRouter API key found. Add one in Settings to begin.",
+          kind: "missingApiKey",
+        });
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd client && npm run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/pages/ask.tsx
+git commit -m "ask: tag missing-API-key error with kind discriminator"
+```
+
+---
+
+## Task 4: Embed `ModelPicker` inside `ChatInput` footer
+
+**Files:**
+- Modify: `client/src/components/chat/ChatInput.tsx`
+
+- [ ] **Step 1: Add model props and render the picker**
+
+Replace the full contents of `client/src/components/chat/ChatInput.tsx` with:
+
+```tsx
+import { type KeyboardEvent, useEffect, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import { ModelPicker } from "./ModelPicker";
+
+interface ChatInputProps {
+  initialValue?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  onSubmit: (text: string) => void;
+  model: string;
+  onModelChange: (modelId: string) => void;
+}
+
+export function ChatInput({
+  initialValue = "",
+  placeholder = "Ask a follow-up…",
+  disabled,
+  onSubmit,
+  model,
+  onModelChange,
+}: ChatInputProps) {
+  const [value, setValue] = useState(initialValue);
+  const [prevInitial, setPrevInitial] = useState(initialValue);
+  const taRef = useRef<HTMLTextAreaElement>(null);
+
+  if (initialValue !== prevInitial) {
+    setPrevInitial(initialValue);
+    setValue(initialValue);
+  }
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: value is the trigger
+  useEffect(() => {
+    const el = taRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+  }, [value]);
+
+  const submit = () => {
+    const trimmed = value.trim();
+    if (!trimmed || disabled) return;
+    setValue("");
+    onSubmit(trimmed);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.nativeEvent.isComposing) return;
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      submit();
+    }
+  };
+
+  const ready = !disabled && value.trim() !== "";
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-border bg-card",
+        "focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/30",
+        "transition-all"
+      )}
+    >
+      <Textarea
+        ref={taRef}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        disabled={disabled}
+        rows={1}
+        className={cn(
+          "border-0 bg-transparent shadow-none resize-none min-h-[44px]",
+          "focus-visible:ring-0 focus-visible:ring-offset-0",
+          "text-[15px] leading-6 px-4 py-3"
+        )}
+      />
+      <div className="flex items-center justify-between gap-2 px-3 py-2 border-t border-border/60">
+        <span className="hidden sm:inline text-[11px] text-muted-foreground">
+          <kbd className="px-1 py-0.5 rounded bg-muted text-muted-foreground text-[10px]">
+            ⏎
+          </kbd>{" "}
+          to send ·{" "}
+          <kbd className="px-1 py-0.5 rounded bg-muted text-muted-foreground text-[10px]">
+            ⇧⏎
+          </kbd>{" "}
+          for newline
+        </span>
+        <div className="flex items-center gap-2 ml-auto">
+          <ModelPicker value={model} onChange={onModelChange} />
+          <Button
+            onClick={submit}
+            disabled={!ready}
+            size="sm"
+            variant={ready ? "default" : "ghost"}
+          >
+            Ask
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd client && npm run typecheck
+```
+
+Expected: `ask.tsx` will error because it doesn't yet pass `model` and `onModelChange`. That is expected — Task 5 wires them up. If any unrelated errors appear, fix them before proceeding.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/components/chat/ChatInput.tsx
+git commit -m "ask: embed ModelPicker inside ChatInput footer"
+```
+
+---
+
+## Task 5: Remove header; pass model props; widen column
+
+**Files:**
+- Modify: `client/src/pages/ask.tsx`
+
+- [ ] **Step 1: Replace the page layout**
+
+Replace the full contents of `client/src/pages/ask.tsx` with the block below. This deletes the header, widens both the messages column and the input wrapper from `max-w-[44rem]` to `max-w-[52rem]`, passes model props to `ChatInput`, and computes `hasApiKey` for the empty-state shortcut (added in Task 7):
+
+```tsx
+import { useSession, useUserData } from "@fluffylabs/shared-ui/supabase";
+import { Sparkles } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { ChatInput } from "@/components/chat/ChatInput";
+import { CitationsPanel } from "@/components/chat/CitationsPanel";
+import { Message } from "@/components/chat/Message";
+import { Button } from "@/components/ui/button";
+import { useAskConversation } from "@/hooks/useAskConversation";
+import { askStream } from "@/lib/askClient";
+import type { AssistantMessage } from "@/lib/askTypes";
+
+export function AskPage() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const searchParams = useMemo(
+    () => new URLSearchParams(location.search),
+    [location.search]
+  );
+  const initialQuery = searchParams.get("q") ?? "";
+  const autoSubmit = searchParams.get("autoSubmit") === "1";
+
+  const { state, dispatch } = useAskConversation();
+  const { isLoading: sessionLoading } = useSession();
+  const { data: keyData, isLoading: keyLoading } = useUserData(
+    "openrouter-api-key",
+    { appScoped: true }
+  );
+  const isReady = !sessionLoading && !keyLoading;
+  const hasApiKey = typeof keyData === "string" && keyData.trim() !== "";
+
+  const streamHandleRef = useRef<{ abort: () => void } | null>(null);
+  const hasAutoSubmittedRef = useRef(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const send = useCallback(
+    (text: string, options?: { startFresh?: boolean }) => {
+      if (!isReady) return;
+      const apiKey = hasApiKey ? (keyData as string) : null;
+      if (!apiKey) {
+        if (options?.startFresh) dispatch({ type: "reset" });
+        dispatch({ type: "sendUserMessage", text });
+        dispatch({
+          type: "setError",
+          message: "No OpenRouter API key found. Add one in Settings to begin.",
+          kind: "missingApiKey",
+        });
+        return;
+      }
+
+      if (options?.startFresh) dispatch({ type: "reset" });
+      dispatch({ type: "sendUserMessage", text });
+
+      const priorMessages = options?.startFresh ? [] : state.messages;
+      const nextMessages = [
+        ...priorMessages,
+        { id: "pending", role: "user" as const, content: text },
+      ];
+
+      streamHandleRef.current = askStream(
+        {
+          messages: nextMessages,
+          model: state.model,
+          openrouterKey: apiKey,
+        },
+        (event) => {
+          switch (event.type) {
+            case "tool_call":
+              dispatch({
+                type: "addToolStep",
+                toolName: event.name,
+                args: event.args,
+              });
+              break;
+            case "tool_result":
+              dispatch({
+                type: "completeToolStep",
+                toolName: event.name,
+                resultCount: event.resultCount,
+                payload: event.payload,
+              });
+              break;
+            case "content_delta":
+              dispatch({ type: "appendContent", text: event.text });
+              break;
+            case "citation":
+              dispatch({
+                type: "addCitation",
+                n: event.n,
+                docId: event.docId,
+                sourceType: event.sourceType,
+              });
+              break;
+            case "done":
+              dispatch({ type: "finishStreaming" });
+              break;
+            case "error":
+              dispatch({ type: "setError", message: event.message });
+              break;
+          }
+        }
+      );
+    },
+    [isReady, hasApiKey, keyData, dispatch, state.messages, state.model]
+  );
+
+  useEffect(() => {
+    if (!autoSubmit || !initialQuery || hasAutoSubmittedRef.current) return;
+    if (!isReady) return;
+
+    hasAutoSubmittedRef.current = true;
+
+    const lastUser = [...state.messages]
+      .reverse()
+      .find((m) => m.role === "user");
+    const lastAssistant = [...state.messages]
+      .reverse()
+      .find((m): m is AssistantMessage => m.role === "assistant");
+    const alreadyAnswered =
+      lastUser?.content === initialQuery &&
+      !!lastAssistant &&
+      !lastAssistant.isStreaming &&
+      !lastAssistant.error;
+
+    if (!alreadyAnswered) {
+      streamHandleRef.current?.abort();
+      send(initialQuery, { startFresh: true });
+    }
+
+    const nextParams = new URLSearchParams(location.search);
+    nextParams.delete("autoSubmit");
+    navigate(`${location.pathname}?${nextParams.toString()}`, {
+      replace: true,
+    });
+  }, [
+    autoSubmit,
+    initialQuery,
+    isReady,
+    location.pathname,
+    location.search,
+    navigate,
+    send,
+    state.messages,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      streamHandleRef.current?.abort();
+    };
+  }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: state.messages is the trigger
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [state.messages]);
+
+  const lastAssistant = [...state.messages]
+    .reverse()
+    .find((m): m is AssistantMessage => m.role === "assistant");
+
+  const streaming = lastAssistant?.isStreaming === true;
+  const isEmpty = state.messages.length === 0;
+
+  const handleNewChat = () => {
+    streamHandleRef.current?.abort();
+    streamHandleRef.current = null;
+    dispatch({ type: "reset" });
+  };
+
+  return (
+    <div className="flex flex-col h-full bg-background">
+      <div className="flex-1 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_22rem] overflow-hidden">
+        <section className="flex flex-col overflow-hidden">
+          <div ref={scrollRef} className="flex-1 overflow-y-auto">
+            {isEmpty ? (
+              <EmptyState
+                showApiKeyCta={isReady && !hasApiKey}
+                onOpenSettings={() => navigate("/settings")}
+              />
+            ) : (
+              <>
+                <div className="sticky top-0 z-10 backdrop-blur bg-background/80 border-b border-border/60">
+                  <div className="max-w-[52rem] mx-auto px-6 py-2 flex justify-end">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleNewChat}
+                    >
+                      New chat
+                    </Button>
+                  </div>
+                </div>
+                <div className="max-w-[52rem] mx-auto px-6 py-8 flex flex-col gap-6">
+                  {state.messages.map((m) => (
+                    <Message key={m.id} message={m} />
+                  ))}
+                </div>
+              </>
+            )}
+          </div>
+
+          <div className="max-w-[52rem] w-full mx-auto px-6 pb-6">
+            <ChatInput
+              initialValue={autoSubmit ? "" : initialQuery}
+              disabled={streaming || !isReady}
+              onSubmit={send}
+              model={state.model}
+              onModelChange={(m) => dispatch({ type: "setModel", model: m })}
+              placeholder={
+                isEmpty
+                  ? "What would you like to know about JAM?"
+                  : "Ask a follow-up…"
+              }
+            />
+          </div>
+        </section>
+
+        <aside className="hidden lg:block border-l border-border overflow-y-auto bg-card/20 px-5 py-6">
+          <CitationsPanel assistant={lastAssistant} cards={state.cards} />
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+interface EmptyStateProps {
+  showApiKeyCta: boolean;
+  onOpenSettings: () => void;
+}
+
+function EmptyState({ showApiKeyCta, onOpenSettings }: EmptyStateProps) {
+  return (
+    <div className="max-w-[36rem] mx-auto px-6 pt-16 pb-8 text-center">
+      <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-brand-light text-brand-dark mb-5">
+        <Sparkles className="h-5 w-5" />
+      </div>
+      <h2 className="text-2xl font-semibold text-foreground mb-3">
+        Ask anything about JAM
+      </h2>
+      <p className="text-sm text-muted-foreground leading-relaxed max-w-[28rem] mx-auto">
+        An agent will search the Graypaper, Discord and Matrix discussions, and
+        indexed pages, then answer with cited sources.
+      </p>
+      {showApiKeyCta && (
+        <div className="mt-6">
+          <Button variant="outline" onClick={onOpenSettings}>
+            Configure OpenRouter API key
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd client && npm run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Lint**
+
+```bash
+cd client && npm run lint
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd client && npm test
+```
+
+Expected: existing tests still pass.
+
+- [ ] **Step 5: Manual verification in dev server**
+
+```bash
+cd client && npm run dev
+```
+
+Open the ask page in a browser. Verify:
+- Header "Ask AI" bar is gone.
+- `ModelPicker` + `Ask` button sit together on the right of the input footer; keyboard hint is on the left (and hides below `sm` breakpoint).
+- With messages present: a "New chat" button sits sticky at the top of the conversation column; it remains visible when scrolling.
+- Clicking "New chat" resets the conversation.
+- In empty state without an API key configured: "Configure OpenRouter API key" button appears below the intro.
+- In empty state with an API key configured: no CTA button appears.
+- Attempting to send without an API key shows the error with a "Go to Settings" button.
+- Conversation column appears wider than before on a ~1280px viewport.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/pages/ask.tsx
+git commit -m "ask: redesign header and layout to reclaim vertical space"
+```
+
+---
+
+## Task 6: Final verification
+
+- [ ] **Step 1: Full client test + lint + typecheck**
+
+```bash
+cd client && npm run lint && npm run typecheck && npm test
+```
+
+Expected: all clean.
+
+- [ ] **Step 2: Confirm branch is clean**
+
+```bash
+git status
+```
+
+Expected: `working tree clean` (all work committed).

--- a/docs/superpowers/specs/2026-04-23-ask-page-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-23-ask-page-redesign-design.md
@@ -78,7 +78,7 @@ rendered in two places only when `isReady && !hasApiKey`:
   missing-API-key string, the error block will include a "Go to
   Settings" button. We detect this either by exact-string match on the
   rendered error, or by extending the error payload with a
-  `kind: "missing-api-key"` discriminator (preferred; cleaner than
+  `kind: "missingApiKey"` discriminator (preferred; cleaner than
   string matching).
 
 The `hasApiKey` boolean is computed in `AskPage` from `keyData` (already
@@ -94,8 +94,12 @@ that the header is gone.
 ## Out of Scope
 
 - `CitationsPanel` / sources column layout.
-- `Message` component rendering.
-- Backend, routing, or `useAskConversation` reducer logic.
+- `Message` component's content rendering (text parts, tool steps,
+  citations). The error block inside `Message.tsx` is in scope and gains
+  a conditional "Go to Settings" button — see Files Touched.
+- Backend and routing. The `useAskConversation` reducer gains a small
+  `errorKind` discriminator (see Files Touched) but no other logic
+  changes.
 
 ## Risks
 

--- a/docs/superpowers/specs/2026-04-23-ask-page-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-23-ask-page-redesign-design.md
@@ -1,0 +1,124 @@
+# Ask Page Redesign
+
+**Date:** 2026-04-23
+**Scope:** `client/src/pages/ask.tsx` and related chat components.
+
+## Goal
+
+Reclaim vertical space on the ask page by removing the top header bar,
+relocating its controls into more contextual locations, and trimming the
+Settings shortcut to a conditional affordance.
+
+## Current State
+
+The ask page currently renders a 60px header (`ask.tsx:181–215`) containing:
+
+- A `Sparkles` icon + "Ask AI" title
+- A `ModelPicker`
+- A "New chat" button (only when messages exist)
+- A persistent "Settings" button
+
+Below the header sits the conversation column (`max-w-[44rem]`) and a
+citations panel on the right.
+
+## Changes
+
+### 1. Remove header bar
+
+Delete the entire `<header>` block in `ask.tsx` (lines 181–215). The
+"Ask AI" title, separator, and associated layout are removed.
+
+### 2. Move ModelPicker into ChatInput
+
+`ChatInput` gains two new props:
+
+```ts
+interface ChatInputProps {
+  // ...existing...
+  model: string;
+  onModelChange: (modelId: string) => void;
+}
+```
+
+The footer row becomes:
+
+- **Left:** keyboard hint (`⏎ to send · ⇧⏎ for newline`) — unchanged.
+- **Right:** `[ModelPicker] [Ask button]` — new grouping.
+
+The page passes `state.model` and a handler that dispatches
+`{ type: "setModel", model }`.
+
+### 3. Sticky "New chat" inside the conversation
+
+Render a sticky button at the top of the scrollable conversation area,
+above the messages list. Only shown when `state.messages.length > 0`.
+
+Behavior:
+
+- `position: sticky; top: 0` so it remains visible while scrolling long
+  threads.
+- Translucent background with `backdrop-blur` so scrolled content reads
+  acceptably behind it.
+- Click handler aborts any in-flight stream and dispatches `reset`
+  (identical logic to today's header button).
+
+Placement is inside the `scrollRef` container so it scrolls with its
+parent but sticks to the top edge.
+
+### 4. Conditional Settings shortcut
+
+The persistent "Settings" button is removed. A Settings affordance is
+rendered in two places only when `isReady && !hasApiKey`:
+
+- **EmptyState:** a button labeled "Configure OpenRouter API key" below
+  the intro paragraph, linking to `/settings`.
+- **Error flow:** errors currently render inside `Message.tsx`
+  (lines 49–53) as a destructive-styled block attached to the last
+  assistant message. When the error message matches the
+  missing-API-key string, the error block will include a "Go to
+  Settings" button. We detect this either by exact-string match on the
+  rendered error, or by extending the error payload with a
+  `kind: "missing-api-key"` discriminator (preferred; cleaner than
+  string matching).
+
+The `hasApiKey` boolean is computed in `AskPage` from `keyData` (already
+available) and passed to `EmptyState`. The error-side Settings link
+does not need `hasApiKey` — it's tied to the specific error kind.
+
+### 5. Expand conversation max-width
+
+Change `max-w-[44rem]` to `max-w-[52rem]` in both the messages list and
+the ChatInput wrapper, so medium screens get more horizontal room now
+that the header is gone.
+
+## Out of Scope
+
+- `CitationsPanel` / sources column layout.
+- `Message` component rendering.
+- Backend, routing, or `useAskConversation` reducer logic.
+
+## Risks
+
+- **Sticky "New chat" overlap:** the sticky button will visually overlap
+  the first message when scrolled. Mitigation: translucent
+  backdrop-blur background so overlap is acceptable; appropriate top
+  padding on the messages container.
+- **Model picker width in footer:** on narrow widths the keyboard hint
+  may crowd. Acceptable to hide the hint on sub-`sm` breakpoints
+  (`hidden sm:inline`).
+- **Settings discoverability for configured users:** intentional per
+  user request. Configured users navigate to settings via app nav.
+
+## Files Touched
+
+- `client/src/pages/ask.tsx` — remove header, add sticky new-chat, add
+  conditional empty-state settings link, widen max-width, pass model
+  props to ChatInput.
+- `client/src/components/chat/ChatInput.tsx` — accept model props,
+  render ModelPicker next to Ask button.
+- `client/src/components/chat/Message.tsx` — extend error block
+  rendering to include a "Go to Settings" button when the error is the
+  missing-API-key case.
+- `client/src/lib/askReducer.ts` — extend the assistant-message error
+  field (or add a sibling `errorKind`) so `Message.tsx` can distinguish
+  the missing-API-key case from generic errors.


### PR DESCRIPTION
## Summary

- **Layout:** remove the ask page header bar. Move `ModelPicker` into the `ChatInput` footer, move "New chat" to a sticky control inside the conversation, and make the Settings shortcut a conditional affordance that only appears when no OpenRouter API key is configured. Widen the conversation column to `52rem`.
- **Full-bleed on `/ask`:** drop the shared `p-4 overflow-y-auto` wrapper for the `/ask` route so the section/aside divider spans the full content-area height.
- **Groove borders:** pair a subtle `border-r`/`border-l` on both sides of the sidebar↔main-content and section↔aside seams for an inset effect in both themes.
- **Dark-mode readability fixes (app-wide):**
  - `ghost` and `outline` button variants were missing a base text color — added `text-foreground`. Fixes the "New chat", "Go to Settings", "Configure OpenRouter API key", and `ModelPicker` trigger buttons.
  - `Textarea` was missing a base text color — added `text-foreground`. Fixes the prompt input.
  - `--popover` in dark mode was `hsl(190 84% 4.9%)` (nearly black) against the `hsl(0 0% 20%)` ambient background; realigned to `--card` and `--popover-foreground` to `--foreground` for sane elevation.
  - Selected model in the dropdown now uses `text-brand-dark dark:text-brand` instead of a near-black teal in dark mode.
  - Empty-state Sparkles circle now flips to `bg-brand-dark` with `text-brand` in dark mode, matching the home page icon pattern.
- **Reducer:** added an `errorKind` discriminator on assistant messages so the "Go to Settings" CTA renders only for the missing-API-key error (cleaner than string-matching the error message).

## Test plan

- [ ] Header is gone; page uses its full vertical height.
- [ ] Input footer shows `[keyboard hint] [Model] [Ask]`.
- [ ] "New chat" sticks to the top of the conversation while scrolling.
- [ ] Empty state without API key shows "Configure OpenRouter API key" button; with a key, no button.
- [ ] Sending without an API key renders the error block with a "Go to Settings" button.
- [ ] Section/aside border spans the full height of the page.
- [ ] All buttons (ghost, outline), the textarea, and the model picker trigger read clearly in dark mode.
- [ ] Opening the model picker shows a dropdown that reads as a mild elevation, not a near-black panel with a light border.
- [ ] Home page and other pages keep their existing padding; only `/ask` opts out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model selector moved into the chat input footer
  * Sticky "New Chat" button inside the conversation area
  * Contextual "Go to Settings" and "Configure OpenRouter API key" CTAs when API key is missing
  * Wider conversation area for improved readability

* **Bug Fixes**
  * Improved selected-model visibility in dark mode
  * Consistent text color for buttons and textareas
  * Popover colors aligned with theme variables

* **Tests**
  * Added reducer tests covering error-kind behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->