### PR TITLE
Bring back MCP endpoint, scoped to the two /ask tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ npm run generate-embeddings   # Generate vector embeddings
 
 Automated jobs run daily to keep content updated.
 
+## MCP
+
+The backend also exposes a [Model Context Protocol](https://modelcontextprotocol.io)
+endpoint at `/mcp` with two tools (`search_all`, `get_full_document`) — the
+same tools the `/ask` assistant uses. Point any MCP-compatible client at
+`https://search-api.fluffylabs.dev/mcp` to query the index. See
+[`backend/README.md`](./backend/README.md#mcp) for details.
+
 ## Deployment
 
 - **Backend**: Deployed to <https://search-api.fluffylabs.dev>

--- a/backend/README.md
+++ b/backend/README.md
@@ -106,10 +106,22 @@ two tools the `/ask` agent uses:
 - `get_full_document(id)` — fetch the full markdown of a document by id
   returned from `search_all`.
 
+### Design choices
+
+- **Stateless.** A fresh `Server` + `Transport` is created per request. No
+  session state is kept between calls; `initialize` does not return an
+  `mcp-session-id` header and there is no `GET` / `DELETE` lifecycle. Any
+  MCP client that supports stateless Streamable HTTP works.
+- **No CORS.** `/mcp` intentionally sets no `Access-Control-Allow-Origin`
+  header. It is meant for server-to-server / local MCP clients, not browser
+  origins. The other endpoints still apply CORS for the frontend.
+- **No embeddings.** Tool calls run fulltext-only search; the server's
+  OpenAI quota is never spent on anonymous MCP traffic. `/ask` still uses
+  hybrid search because the caller supplies their own OpenRouter key.
+
 ### Connecting a client
 
-Any MCP-compatible client that supports Streamable HTTP can use it. Point the
-client at the public deployment or your local dev server:
+Point any MCP client at the public deployment or your local dev server:
 
 - Production: `https://search-api.fluffylabs.dev/mcp`
 - Local dev: `http://localhost:3000/mcp`
@@ -128,27 +140,27 @@ Example Claude Desktop (`claude_desktop_config.json`) entry:
 
 ### Manual probe
 
-You can drive the endpoint with `curl`:
+Stateless mode means a single POST per interaction — no session bookkeeping.
 
 ```bash
-# 1. Initialize — capture the returned mcp-session-id header
-curl -i -X POST http://localhost:3000/mcp \
+# Initialize and read the server's advertised capabilities:
+curl -s -X POST http://localhost:3000/mcp \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json, text/event-stream' \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize",
        "params":{"protocolVersion":"2025-03-26","capabilities":{},
                  "clientInfo":{"name":"probe","version":"0.0.1"}}}'
 
-# 2. Send the initialized notification, then list/call tools using the
-#    session id from the previous response.
-SID=<copy from mcp-session-id response header>
-curl -X POST http://localhost:3000/mcp \
-  -H "mcp-session-id: $SID" -H 'Content-Type: application/json' \
-  -H 'Accept: application/json, text/event-stream' \
-  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'
-
-curl -X POST http://localhost:3000/mcp \
-  -H "mcp-session-id: $SID" -H 'Content-Type: application/json' \
+# List the two tools:
+curl -s -X POST http://localhost:3000/mcp \
+  -H 'Content-Type: application/json' \
   -H 'Accept: application/json, text/event-stream' \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+
+# Call search_all:
+curl -s -X POST http://localhost:3000/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call",
+       "params":{"name":"search_all","arguments":{"query":"refine"}}}'
 ```

--- a/backend/README.md
+++ b/backend/README.md
@@ -72,3 +72,83 @@ The application includes scheduled cron jobs that run daily to:
 - `GET /search/graypaper` - Search graypaper sections
 - `GET /search/discords` - Search Discord messages
 - `GET /embeddings` - Get embeddings for a query
+- `POST /ask` - Streaming AI assistant (SSE). See [Ask API](#ask-api).
+- `POST|GET|DELETE /mcp` - Model Context Protocol endpoint. See [MCP](#mcp).
+
+## Ask API
+
+`POST /ask` runs an agent loop that answers questions using the JAM knowledge
+base. Responses stream back as Server-Sent Events.
+
+Request body:
+
+```json
+{
+  "messages": [{ "role": "user", "content": "What is a refinement context?" }],
+  "model": "openai/gpt-4o-mini",
+  "openrouterKey": "sk-or-..."
+}
+```
+
+The agent has access to two tools — `search_all` (unified search across all
+sources) and `get_full_document` (fetch full markdown by id). These are the
+same tools exposed via [MCP](#mcp).
+
+## MCP
+
+The backend serves a [Model Context Protocol](https://modelcontextprotocol.io)
+endpoint at `/mcp` using the Streamable HTTP transport. It exposes the same
+two tools the `/ask` agent uses:
+
+- `search_all(query, limit?)` — unified search across graypaper, discord,
+  matrix and pages. Returns an array of result chunks, each with a stable `id`,
+  `sourceType`, and content preview.
+- `get_full_document(id)` — fetch the full markdown of a document by id
+  returned from `search_all`.
+
+### Connecting a client
+
+Any MCP-compatible client that supports Streamable HTTP can use it. Point the
+client at the public deployment or your local dev server:
+
+- Production: `https://search-api.fluffylabs.dev/mcp`
+- Local dev: `http://localhost:3000/mcp`
+
+Example Claude Desktop (`claude_desktop_config.json`) entry:
+
+```json
+{
+  "mcpServers": {
+    "jam-search": {
+      "url": "https://search-api.fluffylabs.dev/mcp"
+    }
+  }
+}
+```
+
+### Manual probe
+
+You can drive the endpoint with `curl`:
+
+```bash
+# 1. Initialize — capture the returned mcp-session-id header
+curl -i -X POST http://localhost:3000/mcp \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize",
+       "params":{"protocolVersion":"2025-03-26","capabilities":{},
+                 "clientInfo":{"name":"probe","version":"0.0.1"}}}'
+
+# 2. Send the initialized notification, then list/call tools using the
+#    session id from the previous response.
+SID=<copy from mcp-session-id response header>
+curl -X POST http://localhost:3000/mcp \
+  -H "mcp-session-id: $SID" -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+
+curl -X POST http://localhost:3000/mcp \
+  -H "mcp-session-id: $SID" -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+```

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^1.19.13",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@octokit/rest": "^22.0.1",
     "@orama/orama": "^3.1.18",
     "cheerio": "^1.2.0",

--- a/backend/src/__tests__/ask/tools.test.ts
+++ b/backend/src/__tests__/ask/tools.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { executeGetFullDocument, executeSearchAll } from "../../ask/tools.js";
+import {
+  executeGetFullDocument,
+  executeSearchAll,
+  TOOL_DEFINITIONS,
+  TOOL_SPECS,
+} from "../../ask/tools.js";
 import { createSearchDB, insertDoc } from "../../data/searchIndex.js";
 
 describe("executeSearchAll", () => {
@@ -76,5 +81,25 @@ describe("executeGetFullDocument", () => {
     const db = createSearchDB();
     const result = await executeGetFullDocument({ id: "does-not-exist" }, db);
     expect(result).toBeNull();
+  });
+});
+
+describe("tool specs", () => {
+  it("TOOL_DEFINITIONS is derived 1:1 from TOOL_SPECS (no duplication)", () => {
+    expect(TOOL_DEFINITIONS.map((d) => d.function.name)).toEqual(
+      TOOL_SPECS.map((s) => s.name)
+    );
+    for (let i = 0; i < TOOL_SPECS.length; i++) {
+      expect(TOOL_DEFINITIONS[i].function.description).toBe(
+        TOOL_SPECS[i].description
+      );
+    }
+  });
+
+  it("search_all parameters do not require `limit`", () => {
+    const spec = TOOL_DEFINITIONS.find((d) => d.function.name === "search_all");
+    expect(spec).toBeDefined();
+    const params = spec?.function.parameters as { required?: string[] };
+    expect(params.required).toEqual(["query"]);
   });
 });

--- a/backend/src/__tests__/mcp/handler.test.ts
+++ b/backend/src/__tests__/mcp/handler.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { createApp } from "../../api.js";
+import { createSearchDB, insertDoc } from "../../data/searchIndex.js";
+
+function initBody() {
+  return {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: { name: "handler-test", version: "0.0.1" },
+    },
+  };
+}
+
+function mcpHeaders() {
+  return {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+  };
+}
+
+describe("/mcp HTTP handler", () => {
+  it("handles initialize stateless (no CORS, no session id) and returns SSE body", async () => {
+    const db = createSearchDB();
+    insertDoc(db, {
+      type: "graypaper_section",
+      title: "Accumulate",
+      content: "The accumulate function processes work results.",
+    });
+    const app = createApp(db, "./data");
+
+    const res = await app.fetch(
+      new Request("http://x/mcp", {
+        method: "POST",
+        headers: mcpHeaders(),
+        body: JSON.stringify(initBody()),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    // CORS must not be advertised for server-to-server endpoint.
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+    // Stateless: transport must not mint a session id.
+    expect(res.headers.get("mcp-session-id")).toBeNull();
+
+    const text = await res.text();
+    expect(text).toContain("protocolVersion");
+    expect(text).toContain("jam-search");
+  });
+
+  it("rejects initialize when Accept header is missing text/event-stream", async () => {
+    const app = createApp(createSearchDB(), "./data");
+    const res = await app.fetch(
+      new Request("http://x/mcp", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(initBody()),
+      })
+    );
+    // MCP transport rejects with 406 when the client didn't advertise SSE.
+    expect(res.status).toBe(406);
+  });
+
+  it("applies CORS to non-MCP routes (sanity check)", async () => {
+    const app = createApp(createSearchDB(), "./data");
+    const res = await app.fetch(
+      new Request("http://x/health", {
+        headers: { Origin: "https://example.com" },
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("access-control-allow-origin")).not.toBeNull();
+  });
+});

--- a/backend/src/__tests__/mcp/server.test.ts
+++ b/backend/src/__tests__/mcp/server.test.ts
@@ -1,0 +1,92 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { createSearchDB, insertDoc } from "../../data/searchIndex.js";
+import { createMcpServer } from "../../mcp/server.js";
+
+async function connectClient(db = createSearchDB()) {
+  const server = createMcpServer(db, "./data");
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test", version: "0.0.0" });
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  return { client, db };
+}
+
+describe("mcp server", () => {
+  it("lists exactly the two /ask tools", async () => {
+    const { client } = await connectClient();
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toEqual(["get_full_document", "search_all"]);
+  });
+
+  it("does not mark `limit` as required on search_all", async () => {
+    const { client } = await connectClient();
+    const { tools } = await client.listTools();
+    const searchAll = tools.find((t) => t.name === "search_all");
+    expect(searchAll).toBeDefined();
+    const required = (searchAll?.inputSchema as { required?: string[] })
+      .required;
+    expect(required).toEqual(["query"]);
+  });
+
+  it("calls search_all and returns a text content block", async () => {
+    const db = createSearchDB();
+    insertDoc(db, {
+      type: "graypaper_section",
+      title: "Accumulate",
+      content: "The accumulate function processes work results.",
+    });
+    const { client } = await connectClient(db);
+
+    const result = await client.callTool({
+      name: "search_all",
+      arguments: { query: "accumulate" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const content = result.content as Array<{ type: string; text: string }>;
+    expect(content[0].type).toBe("text");
+    const parsed = JSON.parse(content[0].text) as Array<{ id: string }>;
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed.length).toBeGreaterThan(0);
+    expect(typeof parsed[0].id).toBe("string");
+  });
+
+  it("calls get_full_document and returns the doc body", async () => {
+    const db = createSearchDB();
+    const id = insertDoc(db, {
+      type: "graypaper_section",
+      title: "Accumulate",
+      content: "Full body of the accumulate section...",
+    });
+    const { client } = await connectClient(db);
+
+    const result = await client.callTool({
+      name: "get_full_document",
+      arguments: { id },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const content = result.content as Array<{ type: string; text: string }>;
+    const parsed = JSON.parse(content[0].text) as {
+      id: string;
+      content: string;
+    };
+    expect(parsed.id).toBe(id);
+    expect(parsed.content).toContain("Full body of the accumulate section");
+  });
+
+  it("returns isError for get_full_document with an unknown id", async () => {
+    const { client } = await connectClient();
+    const result = await client.callTool({
+      name: "get_full_document",
+      arguments: { id: "does-not-exist" },
+    });
+    expect(result.isError).toBe(true);
+  });
+});

--- a/backend/src/__tests__/mcp/server.test.ts
+++ b/backend/src/__tests__/mcp/server.test.ts
@@ -1,22 +1,34 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { createSearchDB, insertDoc } from "../../data/searchIndex.js";
 import { createMcpServer } from "../../mcp/server.js";
 
-async function connectClient(db = createSearchDB()) {
-  const server = createMcpServer(db, "./data");
-  const [clientTransport, serverTransport] =
-    InMemoryTransport.createLinkedPair();
-  const client = new Client({ name: "test", version: "0.0.0" });
-  await Promise.all([
-    server.connect(serverTransport),
-    client.connect(clientTransport),
-  ]);
-  return { client, db };
-}
-
 describe("mcp server", () => {
+  const opened: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    await Promise.all(opened.map((close) => close()));
+    opened.length = 0;
+  });
+
+  async function connectClient(db = createSearchDB()) {
+    const server = createMcpServer(db, "./data");
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test", version: "0.0.0" });
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+    opened.push(async () => {
+      // close() is idempotent in the MCP SDK; closing both sides cleans up
+      // protocol state, transport handlers, and linked transport pair.
+      await Promise.all([client.close(), server.close()]);
+    });
+    return { client, db };
+  }
+
   it("lists exactly the two /ask tools", async () => {
     const { client } = await connectClient();
     const { tools } = await client.listTools();

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -19,7 +19,7 @@ import {
 import { searchPages, searchPagesRequestSchema } from "./api/searchPages.js";
 import { embeddingCache } from "./cache/embeddingCache.js";
 import type { SearchDB } from "./data/searchIndex.js";
-import { handleMcpDelete, handleMcpGet, handleMcpPost } from "./mcp/handler.js";
+import { createMcpHandler } from "./mcp/handler.js";
 
 const isDevelopment = process.env.NODE_ENV === "development";
 
@@ -29,14 +29,18 @@ export function createApp(db: SearchDB, dataDir: string) {
   // Middleware
   app.use(logger());
 
-  app.use(
-    cors({
-      origin: isDevelopment
-        ? (origin) =>
-            /^https?:\/\/localhost(:\d+)?$/.test(origin) ? origin : null
-        : "*",
-    })
-  );
+  // CORS is only relevant for browser-origin callers; /mcp is server-to-server
+  // and must not advertise any allowed origin. Skip the middleware for it.
+  const corsMiddleware = cors({
+    origin: isDevelopment
+      ? (origin) =>
+          /^https?:\/\/localhost(:\d+)?$/.test(origin) ? origin : null
+      : "*",
+  });
+  app.use(async (c, next) => {
+    if (c.req.path === "/mcp") return next();
+    return corsMiddleware(c, next);
+  });
 
   // Health check endpoint
   app.get("/health", (c) => {
@@ -81,11 +85,9 @@ export function createApp(db: SearchDB, dataDir: string) {
 
   app.post("/ask", handleAsk(db, dataDir));
 
-  // MCP (Model Context Protocol) endpoint — exposes the same two tools
-  // the /ask agent uses (search_all + get_full_document) over Streamable HTTP.
-  app.post("/mcp", handleMcpPost);
-  app.get("/mcp", handleMcpGet);
-  app.delete("/mcp", handleMcpDelete);
+  // MCP (Model Context Protocol): stateless Streamable HTTP endpoint exposing
+  // the same two tools the /ask agent uses (search_all + get_full_document).
+  app.all("/mcp", createMcpHandler(db, dataDir));
 
   return app;
 }

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -19,6 +19,11 @@ import {
 import { searchPages, searchPagesRequestSchema } from "./api/searchPages.js";
 import { embeddingCache } from "./cache/embeddingCache.js";
 import type { SearchDB } from "./data/searchIndex.js";
+import {
+  handleMcpDelete,
+  handleMcpGet,
+  handleMcpPost,
+} from "./mcp/handler.js";
 
 const isDevelopment = process.env.NODE_ENV === "development";
 
@@ -79,6 +84,12 @@ export function createApp(db: SearchDB, dataDir: string) {
   });
 
   app.post("/ask", handleAsk(db, dataDir));
+
+  // MCP (Model Context Protocol) endpoint — exposes the same two tools
+  // the /ask agent uses (search_all + get_full_document) over Streamable HTTP.
+  app.post("/mcp", (c) => handleMcpPost(c));
+  app.get("/mcp", (c) => handleMcpGet(c));
+  app.delete("/mcp", (c) => handleMcpDelete(c));
 
   return app;
 }

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -19,11 +19,7 @@ import {
 import { searchPages, searchPagesRequestSchema } from "./api/searchPages.js";
 import { embeddingCache } from "./cache/embeddingCache.js";
 import type { SearchDB } from "./data/searchIndex.js";
-import {
-  handleMcpDelete,
-  handleMcpGet,
-  handleMcpPost,
-} from "./mcp/handler.js";
+import { handleMcpDelete, handleMcpGet, handleMcpPost } from "./mcp/handler.js";
 
 const isDevelopment = process.env.NODE_ENV === "development";
 

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -83,9 +83,9 @@ export function createApp(db: SearchDB, dataDir: string) {
 
   // MCP (Model Context Protocol) endpoint — exposes the same two tools
   // the /ask agent uses (search_all + get_full_document) over Streamable HTTP.
-  app.post("/mcp", (c) => handleMcpPost(c));
-  app.get("/mcp", (c) => handleMcpGet(c));
-  app.delete("/mcp", (c) => handleMcpDelete(c));
+  app.post("/mcp", handleMcpPost);
+  app.get("/mcp", handleMcpGet);
+  app.delete("/mcp", handleMcpDelete);
 
   return app;
 }

--- a/backend/src/ask/tools.ts
+++ b/backend/src/ask/tools.ts
@@ -1,5 +1,6 @@
 import { getByID } from "@orama/orama";
 import OpenAI from "openai";
+import { z } from "zod";
 import * as matrix from "../../../shared/matrix.js";
 import { searchDiscords } from "../api/searchDiscords.js";
 import { searchGraypaper } from "../api/searchGraypapers.js";
@@ -82,13 +83,19 @@ function truncate(text: string, max = 500): string {
 export async function executeSearchAll(
   args: { query: string; limit?: number },
   db: SearchDB,
-  dataDir: string
+  dataDir: string,
+  options: { useEmbeddings?: boolean } = {}
 ): Promise<UnifiedSearchResult[]> {
   const limit = args.limit ?? 10;
 
   // Attempt to compute a query embedding for hybrid (text + vector) search.
   // Falls back to fulltext-only if the API key is absent or the call fails.
-  const embedding = await computeQueryEmbedding(args.query);
+  // MCP callers pass useEmbeddings: false to avoid spending the server's
+  // OpenAI quota on anonymous traffic.
+  const embedding =
+    options.useEmbeddings === false
+      ? null
+      : await computeQueryEmbedding(args.query);
   const embeddingKey = embedding ? embeddingCache.store(embedding) : "";
 
   const [pages, discord, matrixRes, graypaper] = await Promise.all([
@@ -230,51 +237,48 @@ export async function executeGetFullDocument(
 }
 
 /**
- * Tool definitions in OpenAI chat-completions tool format. OpenRouter accepts
- * these unchanged. Only two tools: unified search + full-doc fetch.
+ * Single source of truth for the two tools exposed by both /ask (OpenAI
+ * tool-call format) and /mcp (MCP tools/list format). Each surface derives its
+ * wire format from these specs.
  */
-export const TOOL_DEFINITIONS = [
+export const TOOL_SPECS = [
   {
-    type: "function" as const,
-    function: {
-      name: "search_all",
-      description:
-        "Search across all indexed knowledge sources (graypaper, discord, matrix, pages). Returns up to `limit` result chunks with a stable `id`, a `sourceType`, and a short preview of the content. Use this first to discover relevant material; follow up with get_full_document if a preview is insufficient.",
-      parameters: {
-        type: "object",
-        properties: {
-          query: {
-            type: "string",
-            description: "Natural-language or keyword query.",
-          },
-          limit: {
-            type: "integer",
-            minimum: 1,
-            maximum: 20,
-            default: 10,
-            description: "Max results per source (so up to 4 × limit total).",
-          },
-        },
-        required: ["query"],
-      },
-    },
+    name: "search_all",
+    description:
+      "Search across all indexed knowledge sources (graypaper, discord, matrix, pages). Returns up to `limit` result chunks with a stable `id`, a `sourceType`, and a short preview of the content. Use this first to discover relevant material; follow up with get_full_document if a preview is insufficient.",
+    schema: z.object({
+      query: z.string().describe("Natural-language or keyword query."),
+      // `.optional()` after `.default()` keeps limit out of JSON-schema
+      // `required`, so strict clients don't have to pass a tunable.
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(20)
+        .default(10)
+        .optional()
+        .describe("Max results per source (so up to 4 × limit total)."),
+    }),
   },
   {
-    type: "function" as const,
-    function: {
-      name: "get_full_document",
-      description:
-        "Fetch the full markdown of a single document by the `id` returned from search_all. Use when a search preview is insufficient to answer the question.",
-      parameters: {
-        type: "object",
-        properties: {
-          id: {
-            type: "string",
-            description: "The `id` from a search_all result.",
-          },
-        },
-        required: ["id"],
-      },
-    },
+    name: "get_full_document",
+    description:
+      "Fetch the full markdown of a single document by the `id` returned from search_all. Use when a search preview is insufficient to answer the question.",
+    schema: z.object({
+      id: z.string().describe("The `id` from a search_all result."),
+    }),
   },
-];
+] as const;
+
+/**
+ * OpenAI chat-completions tool format, used by the /ask agent loop.
+ * OpenRouter accepts this unchanged.
+ */
+export const TOOL_DEFINITIONS = TOOL_SPECS.map((spec) => ({
+  type: "function" as const,
+  function: {
+    name: spec.name,
+    description: spec.description,
+    parameters: z.toJSONSchema(spec.schema),
+  },
+}));

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,6 +4,7 @@ import { fetchData } from "./data/fetcher.js";
 import { loadAllData } from "./data/loader.js";
 import { createSearchDB } from "./data/searchIndex.js";
 import { env } from "./env.js";
+import { cleanupMcpTransports, initMcpHandler } from "./mcp/handler.js";
 
 function printEmbeddingsDisabledWarning() {
   const lines = [
@@ -49,6 +50,9 @@ async function main() {
   const db = createSearchDB();
   await loadAllData(db, dataDir, cacheDir, openaiApiKey, embeddingsEnabled);
 
+  // Initialize MCP handler with db + data dir so /mcp sessions can serve tools.
+  initMcpHandler(db, dataDir);
+
   const app = createApp(db, dataDir);
 
   // Start HTTP server
@@ -64,6 +68,7 @@ async function main() {
     if (isShuttingDown) return;
     isShuttingDown = true;
     console.log("Shutting down...");
+    cleanupMcpTransports();
     await new Promise<void>((resolve, reject) => {
       server.close((err?: Error) => (err ? reject(err) : resolve()));
     });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,7 +4,6 @@ import { fetchData } from "./data/fetcher.js";
 import { loadAllData } from "./data/loader.js";
 import { createSearchDB } from "./data/searchIndex.js";
 import { env } from "./env.js";
-import { cleanupMcpTransports, initMcpHandler } from "./mcp/handler.js";
 
 function printEmbeddingsDisabledWarning() {
   const lines = [
@@ -50,9 +49,6 @@ async function main() {
   const db = createSearchDB();
   await loadAllData(db, dataDir, cacheDir, openaiApiKey, embeddingsEnabled);
 
-  // Initialize MCP handler with db + data dir so /mcp sessions can serve tools.
-  initMcpHandler(db, dataDir);
-
   const app = createApp(db, dataDir);
 
   // Start HTTP server
@@ -68,7 +64,6 @@ async function main() {
     if (isShuttingDown) return;
     isShuttingDown = true;
     console.log("Shutting down...");
-    cleanupMcpTransports();
     await new Promise<void>((resolve, reject) => {
       server.close((err?: Error) => (err ? reject(err) : resolve()));
     });

--- a/backend/src/mcp/handler.ts
+++ b/backend/src/mcp/handler.ts
@@ -1,184 +1,30 @@
-import { randomUUID } from "node:crypto";
+// Stateless Streamable HTTP MCP endpoint. Every request gets a fresh
+// Server + Transport pair — no session map, no module-level state.
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
-import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import type { Context } from "hono";
 import type { SearchDB } from "../data/searchIndex.js";
 import { createMcpServer } from "./server.js";
 
-const transports = new Map<string, WebStandardStreamableHTTPServerTransport>();
-
-let _db: SearchDB | undefined;
-let _dataDir: string | undefined;
-
-export function initMcpHandler(db: SearchDB, dataDir: string): void {
-  _db = db;
-  _dataDir = dataDir;
-}
-
-function getSessionId(c: Context): string | undefined {
-  return c.req.header("mcp-session-id");
-}
-
-async function createTransportForSession(): Promise<{
-  transport: WebStandardStreamableHTTPServerTransport;
-  server: ReturnType<typeof createMcpServer>;
-}> {
-  if (!_db || !_dataDir) {
-    throw new Error("MCP handler not initialized — call initMcpHandler first");
-  }
-  const server = createMcpServer(_db, _dataDir);
-  const transport = new WebStandardStreamableHTTPServerTransport({
-    sessionIdGenerator: () => randomUUID(),
-    onsessioninitialized: (sessionId: string) => {
-      console.log(`MCP session initialized: ${sessionId}`);
-      transports.set(sessionId, transport);
-    },
-  });
-
-  server.onclose = async () => {
-    const sid = transport.sessionId;
-    if (sid && transports.has(sid)) {
-      console.log(`MCP transport closed for session ${sid}`);
-      transports.delete(sid);
-    }
-  };
-
-  await server.connect(transport);
-  return { transport, server };
-}
-
-export async function handleMcpPost(c: Context): Promise<Response> {
-  const sessionId = getSessionId(c);
-
-  let transport: WebStandardStreamableHTTPServerTransport;
-  let body: unknown;
-
-  try {
-    body = await c.req.json();
-  } catch {
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: {
-          code: -32700,
-          message: "Parse error: Invalid JSON",
-        },
-        id: null,
-      },
-      400
-    );
-  }
-
-  if (sessionId && transports.has(sessionId)) {
-    const existingTransport = transports.get(sessionId);
-    if (!existingTransport) {
+export function createMcpHandler(db: SearchDB, dataDir: string) {
+  return async (c: Context): Promise<Response> => {
+    const transport = new WebStandardStreamableHTTPServerTransport();
+    const server = createMcpServer(db, dataDir);
+    try {
+      await server.connect(transport);
+      return await transport.handleRequest(c.req.raw);
+    } catch (error) {
+      console.error("MCP request failed:", error);
       return c.json(
         {
           jsonrpc: "2.0",
           error: {
-            code: -32000,
-            message: "Session not found",
+            code: -32603,
+            message: "Internal server error",
           },
-          id: (body as { id?: unknown })?.id ?? null,
+          id: null,
         },
-        400
+        500
       );
     }
-    transport = existingTransport;
-  } else if (!sessionId && isInitializeRequest(body)) {
-    const result = await createTransportForSession();
-    transport = result.transport;
-  } else {
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: {
-          code: -32000,
-          message: "Bad Request: No valid session ID provided",
-        },
-        id: (body as { id?: unknown })?.id ?? null,
-      },
-      400
-    );
-  }
-
-  return transport.handleRequest(c.req.raw, { parsedBody: body });
-}
-
-export async function handleMcpGet(c: Context): Promise<Response> {
-  const sessionId = getSessionId(c);
-
-  if (!sessionId) {
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: {
-          code: -32000,
-          message: "Bad Request: No session ID provided",
-        },
-        id: null,
-      },
-      400
-    );
-  }
-
-  const transport = transports.get(sessionId);
-  if (!transport) {
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: {
-          code: -32000,
-          message: "Bad Request: Session not found",
-        },
-        id: null,
-      },
-      400
-    );
-  }
-
-  return transport.handleRequest(c.req.raw);
-}
-
-export async function handleMcpDelete(c: Context): Promise<Response> {
-  const sessionId = getSessionId(c);
-
-  if (!sessionId) {
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: {
-          code: -32000,
-          message: "Bad Request: No session ID provided",
-        },
-        id: null,
-      },
-      400
-    );
-  }
-
-  const transport = transports.get(sessionId);
-  if (!transport) {
-    return c.json(
-      {
-        jsonrpc: "2.0",
-        error: {
-          code: -32000,
-          message: "Bad Request: Session not found",
-        },
-        id: null,
-      },
-      400
-    );
-  }
-
-  return transport.handleRequest(c.req.raw);
-}
-
-export function cleanupMcpTransports(): void {
-  for (const [sessionId, transport] of transports) {
-    console.log(`Closing MCP transport for session ${sessionId}`);
-    transport.close().catch(console.error);
-  }
-  transports.clear();
+  };
 }

--- a/backend/src/mcp/handler.ts
+++ b/backend/src/mcp/handler.ts
@@ -1,0 +1,184 @@
+import { randomUUID } from "node:crypto";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
+import type { Context } from "hono";
+import type { SearchDB } from "../data/searchIndex.js";
+import { createMcpServer } from "./server.js";
+
+const transports = new Map<string, WebStandardStreamableHTTPServerTransport>();
+
+let _db: SearchDB | undefined;
+let _dataDir: string | undefined;
+
+export function initMcpHandler(db: SearchDB, dataDir: string): void {
+  _db = db;
+  _dataDir = dataDir;
+}
+
+function getSessionId(c: Context): string | undefined {
+  return c.req.header("mcp-session-id");
+}
+
+async function createTransportForSession(): Promise<{
+  transport: WebStandardStreamableHTTPServerTransport;
+  server: ReturnType<typeof createMcpServer>;
+}> {
+  if (!_db || !_dataDir) {
+    throw new Error("MCP handler not initialized — call initMcpHandler first");
+  }
+  const server = createMcpServer(_db, _dataDir);
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: () => randomUUID(),
+    onsessioninitialized: (sessionId: string) => {
+      console.log(`MCP session initialized: ${sessionId}`);
+      transports.set(sessionId, transport);
+    },
+  });
+
+  server.onclose = async () => {
+    const sid = transport.sessionId;
+    if (sid && transports.has(sid)) {
+      console.log(`MCP transport closed for session ${sid}`);
+      transports.delete(sid);
+    }
+  };
+
+  await server.connect(transport);
+  return { transport, server };
+}
+
+export async function handleMcpPost(c: Context): Promise<Response> {
+  const sessionId = getSessionId(c);
+
+  let transport: WebStandardStreamableHTTPServerTransport;
+  let body: unknown;
+
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        error: {
+          code: -32700,
+          message: "Parse error: Invalid JSON",
+        },
+        id: null,
+      },
+      400
+    );
+  }
+
+  if (sessionId && transports.has(sessionId)) {
+    const existingTransport = transports.get(sessionId);
+    if (!existingTransport) {
+      return c.json(
+        {
+          jsonrpc: "2.0",
+          error: {
+            code: -32000,
+            message: "Session not found",
+          },
+          id: (body as { id?: unknown })?.id ?? null,
+        },
+        400
+      );
+    }
+    transport = existingTransport;
+  } else if (!sessionId && isInitializeRequest(body)) {
+    const result = await createTransportForSession();
+    transport = result.transport;
+  } else {
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        error: {
+          code: -32000,
+          message: "Bad Request: No valid session ID provided",
+        },
+        id: (body as { id?: unknown })?.id ?? null,
+      },
+      400
+    );
+  }
+
+  return transport.handleRequest(c.req.raw, { parsedBody: body });
+}
+
+export async function handleMcpGet(c: Context): Promise<Response> {
+  const sessionId = getSessionId(c);
+
+  if (!sessionId) {
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        error: {
+          code: -32000,
+          message: "Bad Request: No session ID provided",
+        },
+        id: null,
+      },
+      400
+    );
+  }
+
+  const transport = transports.get(sessionId);
+  if (!transport) {
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        error: {
+          code: -32000,
+          message: "Bad Request: Session not found",
+        },
+        id: null,
+      },
+      400
+    );
+  }
+
+  return transport.handleRequest(c.req.raw);
+}
+
+export async function handleMcpDelete(c: Context): Promise<Response> {
+  const sessionId = getSessionId(c);
+
+  if (!sessionId) {
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        error: {
+          code: -32000,
+          message: "Bad Request: No session ID provided",
+        },
+        id: null,
+      },
+      400
+    );
+  }
+
+  const transport = transports.get(sessionId);
+  if (!transport) {
+    return c.json(
+      {
+        jsonrpc: "2.0",
+        error: {
+          code: -32000,
+          message: "Bad Request: Session not found",
+        },
+        id: null,
+      },
+      400
+    );
+  }
+
+  return transport.handleRequest(c.req.raw);
+}
+
+export function cleanupMcpTransports(): void {
+  for (const [sessionId, transport] of transports) {
+    console.log(`Closing MCP transport for session ${sessionId}`);
+    transport.close().catch(console.error);
+  }
+  transports.clear();
+}

--- a/backend/src/mcp/server.ts
+++ b/backend/src/mcp/server.ts
@@ -1,6 +1,7 @@
-// MCP server exposing the same two tools as the /ask agent. The tool handlers
-// delegate to executeSearchAll / executeGetFullDocument in ../ask/tools.ts so
-// both surfaces share one implementation — keep tool semantics in sync there.
+// MCP server exposing the same two tools as the /ask agent. Tool specs and
+// implementations are sourced from ../ask/tools.ts so both surfaces stay in
+// sync. MCP explicitly disables embeddings to keep the server's OpenAI quota
+// off the anonymous path.
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import {
   CallToolRequestSchema,
@@ -8,41 +9,22 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 
-import { executeGetFullDocument, executeSearchAll } from "../ask/tools.js";
+import {
+  executeGetFullDocument,
+  executeSearchAll,
+  TOOL_SPECS,
+} from "../ask/tools.js";
 import type { SearchDB } from "../data/searchIndex.js";
 
-const SearchAllInputSchema = z.object({
-  query: z.string().describe("Natural-language or keyword query."),
-  // `.optional()` after `.default()` keeps `limit` out of JSON-schema `required`,
-  // so strict MCP clients don't have to pass it explicitly.
-  limit: z
-    .number()
-    .int()
-    .min(1)
-    .max(20)
-    .default(10)
-    .optional()
-    .describe("Max results per source (so up to 4 × limit total)."),
-});
+const MCP_TOOLS = TOOL_SPECS.map((spec) => ({
+  name: spec.name,
+  description: spec.description,
+  inputSchema: z.toJSONSchema(spec.schema),
+}));
 
-const GetFullDocumentInputSchema = z.object({
-  id: z.string().describe("The `id` from a search_all result."),
-});
-
-const TOOLS = [
-  {
-    name: "search_all",
-    description:
-      "Search across all indexed knowledge sources (graypaper, discord, matrix, pages). Returns up to `limit` result chunks per source with a stable `id`, a `sourceType`, and a short preview. Use this first to discover relevant material; follow up with get_full_document if a preview is insufficient.",
-    inputSchema: z.toJSONSchema(SearchAllInputSchema),
-  },
-  {
-    name: "get_full_document",
-    description:
-      "Fetch the full markdown of a single document by the `id` returned from search_all. Use when a search preview is insufficient to answer the question.",
-    inputSchema: z.toJSONSchema(GetFullDocumentInputSchema),
-  },
-];
+function specFor(name: string) {
+  return TOOL_SPECS.find((spec) => spec.name === name);
+}
 
 export function createMcpServer(db: SearchDB, dataDir: string): Server {
   const server = new Server(
@@ -58,7 +40,7 @@ export function createMcpServer(db: SearchDB, dataDir: string): Server {
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {
-    return { tools: TOOLS };
+    return { tools: MCP_TOOLS };
   });
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
@@ -67,14 +49,23 @@ export function createMcpServer(db: SearchDB, dataDir: string): Server {
     try {
       switch (name) {
         case "search_all": {
-          const parsed = SearchAllInputSchema.parse(args);
-          const results = await executeSearchAll(parsed, db, dataDir);
+          const spec = specFor("search_all");
+          if (!spec) throw new Error("search_all spec missing");
+          const parsed = spec.schema.parse(args) as {
+            query: string;
+            limit?: number;
+          };
+          const results = await executeSearchAll(parsed, db, dataDir, {
+            useEmbeddings: false,
+          });
           return {
             content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
           };
         }
         case "get_full_document": {
-          const parsed = GetFullDocumentInputSchema.parse(args);
+          const spec = specFor("get_full_document");
+          if (!spec) throw new Error("get_full_document spec missing");
+          const parsed = spec.schema.parse(args) as { id: string };
           const doc = await executeGetFullDocument(parsed, db);
           if (!doc) {
             return {

--- a/backend/src/mcp/server.ts
+++ b/backend/src/mcp/server.ts
@@ -1,3 +1,6 @@
+// MCP server exposing the same two tools as the /ask agent. The tool handlers
+// delegate to executeSearchAll / executeGetFullDocument in ../ask/tools.ts so
+// both surfaces share one implementation — keep tool semantics in sync there.
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import {
   CallToolRequestSchema,
@@ -10,12 +13,15 @@ import type { SearchDB } from "../data/searchIndex.js";
 
 const SearchAllInputSchema = z.object({
   query: z.string().describe("Natural-language or keyword query."),
+  // `.optional()` after `.default()` keeps `limit` out of JSON-schema `required`,
+  // so strict MCP clients don't have to pass it explicitly.
   limit: z
     .number()
     .int()
     .min(1)
     .max(20)
     .default(10)
+    .optional()
     .describe("Max results per source (so up to 4 × limit total)."),
 });
 

--- a/backend/src/mcp/server.ts
+++ b/backend/src/mcp/server.ts
@@ -86,9 +86,20 @@ export function createMcpServer(db: SearchDB, dataDir: string): Server {
           };
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      // Zod validation errors describe the caller's own input and are safe
+      // (and useful) to surface. Anything else might contain internal detail
+      // like file paths or DB errors — log server-side, return generic text.
+      if (error instanceof z.ZodError) {
+        return {
+          content: [
+            { type: "text", text: `Invalid arguments: ${error.message}` },
+          ],
+          isError: true,
+        };
+      }
+      console.error("MCP tool execution failed:", error);
       return {
-        content: [{ type: "text", text: `Error: ${message}` }],
+        content: [{ type: "text", text: "Tool execution failed" }],
         isError: true,
       };
     }

--- a/backend/src/mcp/server.ts
+++ b/backend/src/mcp/server.ts
@@ -1,0 +1,101 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+
+import { executeGetFullDocument, executeSearchAll } from "../ask/tools.js";
+import type { SearchDB } from "../data/searchIndex.js";
+
+const SearchAllInputSchema = z.object({
+  query: z.string().describe("Natural-language or keyword query."),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(20)
+    .default(10)
+    .describe("Max results per source (so up to 4 × limit total)."),
+});
+
+const GetFullDocumentInputSchema = z.object({
+  id: z.string().describe("The `id` from a search_all result."),
+});
+
+const TOOLS = [
+  {
+    name: "search_all",
+    description:
+      "Search across all indexed knowledge sources (graypaper, discord, matrix, pages). Returns up to `limit` result chunks per source with a stable `id`, a `sourceType`, and a short preview. Use this first to discover relevant material; follow up with get_full_document if a preview is insufficient.",
+    inputSchema: z.toJSONSchema(SearchAllInputSchema),
+  },
+  {
+    name: "get_full_document",
+    description:
+      "Fetch the full markdown of a single document by the `id` returned from search_all. Use when a search preview is insufficient to answer the question.",
+    inputSchema: z.toJSONSchema(GetFullDocumentInputSchema),
+  },
+];
+
+export function createMcpServer(db: SearchDB, dataDir: string): Server {
+  const server = new Server(
+    {
+      name: "jam-search",
+      version: "1.0.0",
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+    }
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return { tools: TOOLS };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+
+    try {
+      switch (name) {
+        case "search_all": {
+          const parsed = SearchAllInputSchema.parse(args);
+          const results = await executeSearchAll(parsed, db, dataDir);
+          return {
+            content: [{ type: "text", text: JSON.stringify(results, null, 2) }],
+          };
+        }
+        case "get_full_document": {
+          const parsed = GetFullDocumentInputSchema.parse(args);
+          const doc = await executeGetFullDocument(parsed, db);
+          if (!doc) {
+            return {
+              content: [
+                { type: "text", text: `Document not found: ${parsed.id}` },
+              ],
+              isError: true,
+            };
+          }
+          return {
+            content: [{ type: "text", text: JSON.stringify(doc, null, 2) }],
+          };
+        }
+        default:
+          return {
+            content: [{ type: "text", text: `Unknown tool: ${name}` }],
+            isError: true,
+          };
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        content: [{ type: "text", text: `Error: ${message}` }],
+        isError: true,
+      };
+    }
+  });
+
+  return server;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@hono/node-server": "^1.19.13",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "@octokit/rest": "^22.0.1",
         "@orama/orama": "^3.1.18",
         "cheerio": "^1.2.0",
@@ -1754,6 +1755,46 @@
       "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
       "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -4473,6 +4514,19 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -4510,6 +4564,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-regex": {
@@ -4606,6 +4677,46 @@
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -4655,6 +4766,44 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -4927,6 +5076,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/conventional-changelog-angular": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
@@ -4961,6 +5132,41 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
@@ -5009,7 +5215,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -5100,6 +5305,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -5262,6 +5476,26 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.336",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz",
@@ -5274,6 +5508,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
@@ -5331,12 +5574,42 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -5388,6 +5661,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -5643,6 +5922,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -5651,6 +5960,67 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.0.tgz",
+      "integrity": "sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/extend": {
@@ -5789,6 +6159,27 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -5827,6 +6218,24 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5839,6 +6248,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gensync": {
@@ -5860,6 +6278,30 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-nonce": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
@@ -5867,6 +6309,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -5939,6 +6394,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -5990,6 +6457,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hast-util-to-jsx-runtime": {
@@ -6114,6 +6605,26 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
@@ -6190,6 +6701,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/ini": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
@@ -6204,6 +6721,24 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -6317,11 +6852,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jiti": {
@@ -6331,6 +6871,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -6382,6 +6931,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -6832,6 +7387,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
@@ -7114,10 +7678,31 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
       "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7689,6 +8274,31 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -7742,6 +8352,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
@@ -7761,6 +8380,27 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -7771,6 +8411,27 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/openai": {
       "version": "6.34.0",
@@ -7947,6 +8608,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -7976,10 +8646,19 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -8005,6 +8684,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/postcss": {
@@ -8055,6 +8743,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -8063,6 +8764,61 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/raw-body/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/react": {
@@ -8375,6 +9131,22 @@
       "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
       "license": "MIT"
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -8412,17 +9184,67 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -8435,10 +9257,81 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -8479,6 +9372,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "4.0.0",
@@ -8663,6 +9565,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -8761,6 +9672,20 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typescript": {
@@ -8908,6 +9833,15 @@
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
       "license": "ISC"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -9002,6 +9936,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vfile": {
@@ -9225,7 +10168,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -9280,6 +10222,12 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.20.0",
@@ -9365,6 +10313,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zod-validation-error": {


### PR DESCRIPTION
## Summary

- Re-adds the MCP (Model Context Protocol) endpoint at `POST/GET/DELETE /mcp` using Streamable HTTP with session management.
- Exposes only the two tools the `/ask` agent uses: `search_all` and `get_full_document`. The MCP tool handlers call the same `executeSearchAll` / `executeGetFullDocument` helpers from `backend/src/ask/tools.ts`, so both surfaces stay in sync.
- Adds `@modelcontextprotocol/sdk@^1.29.0` to the backend.

The original MCP server (commit `ecac46b`, removed 2026-04-17) exposed five per-source search tools. This version intentionally restricts the surface to the unified tool pair, matching the current `/ask` agent.

## Test plan

- [x] `npm run typecheck` clean
- [x] Smoke-tested the live endpoint: `initialize` handshake, `tools/list` returns exactly `search_all` + `get_full_document`, `tools/call search_all` returns real indexed results
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Model Context Protocol (MCP) endpoint at /mcp exposing two tools: search_all and get_full_document.
  * search_all can run as fulltext-only (no embeddings) for anonymous/stateless traffic.

* **Behavior Change**
  * /mcp responses intentionally omit CORS headers; other endpoints retain CORS.

* **Documentation**
  * Added docs and examples for MCP, tools, and the /ask streaming endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->