### PR TITLE
ask: attribute each response to the model that produced it

### DIFF
--- a/backend/src/__tests__/ask/agentLoop.test.ts
+++ b/backend/src/__tests__/ask/agentLoop.test.ts
@@ -55,6 +55,96 @@ describe("runAgentLoop", () => {
     ]);
   });
 
+  it("emits model_used with the actual model from the OpenRouter chunk", async () => {
+    const client = fakeOpenAI([
+      toAsyncIterable([
+        {
+          model: "anthropic/claude-sonnet-4.5",
+          choices: [{ delta: { content: "ok" }, finish_reason: "stop" }],
+        },
+      ]),
+    ]);
+
+    const events = await collect(
+      runAgentLoop({
+        messages: [{ role: "user", content: "q" }],
+        model: "openrouter/auto",
+        openai: client as never,
+        db: createSearchDB(),
+        dataDir: "./data",
+      })
+    );
+
+    expect(events[0]).toEqual({
+      type: "model_used",
+      model: "anthropic/claude-sonnet-4.5",
+    });
+    expect(events.filter((e) => e.type === "model_used")).toHaveLength(1);
+  });
+
+  it("re-emits model_used only when the underlying model changes between iterations", async () => {
+    const db = createSearchDB();
+    insertDoc(db, {
+      type: "graypaper_section",
+      title: "Accumulate",
+      content: "Accumulate body",
+    });
+
+    const client = fakeOpenAI([
+      // Iteration 1 (tool call): all chunks report model A.
+      toAsyncIterable([
+        {
+          model: "model/a",
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    index: 0,
+                    id: "call_1",
+                    type: "function",
+                    function: {
+                      name: "search_all",
+                      arguments: '{"query":"accumulate"}',
+                    },
+                  },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        },
+        {
+          model: "model/a",
+          choices: [{ delta: {}, finish_reason: "tool_calls" }],
+        },
+      ]),
+      // Iteration 2 (final answer): model switches to B.
+      toAsyncIterable([
+        {
+          model: "model/b",
+          choices: [{ delta: { content: "done." }, finish_reason: "stop" }],
+        },
+      ]),
+    ]);
+
+    const events = await collect(
+      runAgentLoop({
+        messages: [{ role: "user", content: "q" }],
+        model: "openrouter/auto",
+        openai: client as never,
+        db,
+        dataDir: "./data",
+      })
+    );
+
+    const modelEvents = events.filter((e) => e.type === "model_used");
+    expect(modelEvents).toEqual([
+      { type: "model_used", model: "model/a" },
+      { type: "model_used", model: "model/b" },
+    ]);
+  });
+
   it("executes a tool call and emits tool_call + tool_result", async () => {
     const db = createSearchDB();
     insertDoc(db, {

--- a/backend/src/ask/agentLoop.ts
+++ b/backend/src/ask/agentLoop.ts
@@ -35,6 +35,7 @@ export async function* runAgentLoop(
   ];
 
   let iterations = 0;
+  let lastReportedModel: string | null = null;
   try {
     while (true) {
       iterations++;
@@ -58,6 +59,7 @@ export async function* runAgentLoop(
       const citeParser = createCiteParser();
 
       for await (const chunk of stream as AsyncIterable<{
+        model?: string;
         choices: Array<{
           delta: {
             content?: string;
@@ -71,6 +73,14 @@ export async function* runAgentLoop(
           finish_reason: string | null;
         }>;
       }>) {
+        // OpenRouter populates `chunk.model` with the actual underlying model
+        // it routed to (for `openrouter/auto`, this can differ per iteration).
+        // Emit when it changes so the frontend can display attribution that
+        // matches what really ran.
+        if (chunk.model && chunk.model !== lastReportedModel) {
+          lastReportedModel = chunk.model;
+          yield { type: "model_used", model: chunk.model };
+        }
         const choice = chunk.choices?.[0];
         if (!choice) continue;
         const delta = choice.delta;

--- a/backend/src/ask/types.ts
+++ b/backend/src/ask/types.ts
@@ -38,6 +38,7 @@ export type AgentEvent =
     }
   | { type: "content_delta"; text: string }
   | { type: "citation"; n: number; docId: string; sourceType: SourceType }
+  | { type: "model_used"; model: string }
   | { type: "done" }
   | { type: "error"; message: string };
 

--- a/client/src/components/chat/Message.tsx
+++ b/client/src/components/chat/Message.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import type { AssistantPart, ChatMessage, TextPart } from "@/lib/askTypes";
+import { modelLabel } from "@/lib/models";
 import { cn } from "@/lib/utils";
 import { Markdown } from "./Markdown";
 import { ToolStep } from "./ToolStep";
@@ -63,6 +64,12 @@ export function Message({ message }: MessageProps) {
               Go to Settings
             </Button>
           )}
+        </div>
+      )}
+
+      {message.model && (
+        <div className="text-[11px] text-muted-foreground/80">
+          via {modelLabel(message.model)}
         </div>
       )}
     </div>

--- a/client/src/lib/__tests__/askReducer.test.ts
+++ b/client/src/lib/__tests__/askReducer.test.ts
@@ -31,6 +31,28 @@ describe("askReducer", () => {
     const last = lastAssistant(next);
     expect(last.parts).toEqual([]);
     expect(last.isStreaming).toBe(true);
+    // Eager attribution: the new assistant message is tagged with whatever
+    // model the picker is on at send time.
+    expect(last.model).toBe(initialState.model);
+  });
+
+  it("sendUserMessage tags the new assistant message with the current model", () => {
+    let s = askReducer(initialState, {
+      type: "setModel",
+      model: "openai/gpt-5",
+    });
+    s = askReducer(s, { type: "sendUserMessage", text: "hi" });
+    expect(lastAssistant(s).model).toBe("openai/gpt-5");
+  });
+
+  it("setMessageModel overwrites the model on the last assistant message", () => {
+    let s = freshAssistant();
+    expect(lastAssistant(s).model).toBe(initialState.model);
+    s = askReducer(s, {
+      type: "setMessageModel",
+      model: "anthropic/claude-sonnet-4.5",
+    });
+    expect(lastAssistant(s).model).toBe("anthropic/claude-sonnet-4.5");
   });
 
   it("appendContent merges consecutive text deltas into a single text part", () => {

--- a/client/src/lib/askReducer.ts
+++ b/client/src/lib/askReducer.ts
@@ -37,6 +37,7 @@ export type AskAction =
   | { type: "finishStreaming" }
   | { type: "setError"; message: string; kind?: ErrorKind }
   | { type: "setModel"; model: string }
+  | { type: "setMessageModel"; model: string }
   | { type: "reset" }
   | { type: "hydrate"; state: AskConversationState };
 
@@ -148,6 +149,10 @@ export function askReducer(
         parts: [],
         citations: [],
         isStreaming: true,
+        // Eager attribution: snapshot the user-selected model at send time.
+        // Will be overwritten by `setMessageModel` once the backend reports
+        // the actual model OpenRouter routed to.
+        model: state.model,
       };
       return {
         ...state,
@@ -245,6 +250,15 @@ export function askReducer(
 
     case "setModel":
       return { ...state, model: action.model };
+
+    case "setMessageModel":
+      return {
+        ...state,
+        messages: mapLastAssistant(state.messages, (m) => ({
+          ...m,
+          model: action.model,
+        })),
+      };
 
     case "reset":
       return { ...initialState, model: state.model };

--- a/client/src/lib/askTypes.ts
+++ b/client/src/lib/askTypes.ts
@@ -13,6 +13,7 @@ export type AgentEvent =
     }
   | { type: "content_delta"; text: string }
   | { type: "citation"; n: number; docId: string; sourceType: SourceType }
+  | { type: "model_used"; model: string }
   | { type: "done" }
   | { type: "error"; message: string };
 
@@ -72,6 +73,11 @@ export interface AssistantMessage {
   error?: string;
   errorKind?: ErrorKind;
   isStreaming: boolean;
+  /** Model that produced this response. Tagged with the user-selected id at
+   *  send time, then overwritten with the actual id once the backend reports
+   *  it via `model_used`. Optional for backwards-compat with conversations
+   *  persisted before this field existed. */
+  model?: string;
 }
 
 /** Flatten an assistant message's text parts into a single string. Used when

--- a/client/src/lib/models.ts
+++ b/client/src/lib/models.ts
@@ -38,3 +38,12 @@ export const MODELS: ModelOption[] = [
 
 /** Default is a balanced Sonnet — good tool use without Opus latency/cost. */
 export const DEFAULT_MODEL = "anthropic/claude-sonnet-4.5";
+
+/**
+ * Display label for a model id. Uses the curated list when possible so
+ * familiar names like "Claude Sonnet 4.5" appear instead of raw ids; falls
+ * back to the raw id for whatever OpenRouter routes to outside the list.
+ */
+export function modelLabel(id: string): string {
+  return MODELS.find((m) => m.id === id)?.label ?? id;
+}

--- a/client/src/pages/ask.tsx
+++ b/client/src/pages/ask.tsx
@@ -92,6 +92,9 @@ export function AskPage() {
                 sourceType: event.sourceType,
               });
               break;
+            case "model_used":
+              dispatch({ type: "setMessageModel", model: event.model });
+              break;
             case "done":
               dispatch({ type: "finishStreaming" });
               break;

--- a/docs/superpowers/specs/2026-04-23-per-message-model-attribution-design.md
+++ b/docs/superpowers/specs/2026-04-23-per-message-model-attribution-design.md
@@ -1,0 +1,62 @@
+# Per-Message Model Attribution
+
+## Problem
+
+The Ask page lets users switch OpenRouter models mid-conversation, but the
+conversation only stores a single top-level `model` field — the picker's
+current value. After persistence (sessionStorage), there's no record of
+which model produced which assistant response. With `openrouter/auto`
+selected, even within a single user-selected setting the actual model can
+change per request, and the frontend never sees what really ran.
+
+## Goal
+
+Show the model used under each assistant message, including for messages
+produced by previous turns of a persisted conversation. The displayed
+attribution should reflect the real underlying model, not just the picker
+value.
+
+## Approach (Option C: eager + actual)
+
+1. Tag the new `AssistantMessage` with the user-selected model id at send
+   time (eager — gives us *something* to display before the first chunk
+   arrives, and a fallback if the stream errors before reporting).
+2. Backend reads the actual model id from each OpenRouter streaming chunk
+   (`chunk.model`) and emits a new `model_used` SSE event whenever it
+   changes.
+3. Frontend dispatches `setMessageModel` on receipt, overwriting the
+   message's `model` field — last-write-wins. With agent loops that may
+   span multiple iterations under `auto`, the field ends up holding the
+   final iteration's model, which is the one that produced the visible
+   text.
+
+## Display
+
+Always-on, muted footer under each assistant message: `via Claude Sonnet
+4.5`. Label resolved via the curated `MODELS` list; falls back to the raw
+id for anything OpenRouter routes to outside the list.
+
+Pre-feature persisted messages have no `model` field — the footer is
+simply not rendered for those.
+
+## Components Touched
+
+- `backend/src/ask/types.ts` — add `model_used` to `AgentEvent`
+- `backend/src/ask/agentLoop.ts` — read `chunk.model`, emit on change
+- `client/src/lib/askTypes.ts` — add `model_used` event; `model?: string`
+  on `AssistantMessage`
+- `client/src/lib/askReducer.ts` — eager tag in `sendUserMessage`; new
+  `setMessageModel` action
+- `client/src/pages/ask.tsx` — wire `model_used` → `setMessageModel`
+- `client/src/lib/models.ts` — `modelLabel(id)` helper
+- `client/src/components/chat/Message.tsx` — render the footer
+
+## What's Out of Scope
+
+- Showing model only on change (D2) — explicitly rejected in favor of
+  always-on (D1).
+- Sending per-message model history back to the backend — backend uses the
+  current `state.model` for the next request; per-message attribution is a
+  display-only concern.
+- Backfilling the `model` field on conversations persisted before this
+  change.


### PR DESCRIPTION
## Summary
- Switching models mid-conversation previously left no per-response record. With `openrouter/auto`, even a single picker setting hid the actually-routed model entirely. After persistence, all of this collapsed to a single top-level `model` field.
- Backend now emits a `model_used` SSE event sourced from `chunk.model` on the OpenRouter stream, re-emitting whenever the underlying model changes across agent-loop iterations.
- Frontend tags each `AssistantMessage` with the user-selected id at send time (Option C — eager fallback) and overwrites it with the actual id once `model_used` arrives. A muted footer (`via Claude Sonnet 4.5`) renders under each assistant message; pre-feature persisted messages have no field and stay footer-less.

Design doc: `docs/superpowers/specs/2026-04-23-per-message-model-attribution-design.md`.

## Test plan
- [ ] Send a message with one model; verify the footer matches the picker.
- [ ] Switch the picker, send another message; verify the new message's footer reflects the new model while the previous message keeps its old attribution.
- [ ] Refresh the page; both attributions persist.
- [ ] With `Auto (OpenRouter)` selected, observe the footer transitioning from "Auto (OpenRouter)" to whatever was actually routed once the first chunk arrives.
- [ ] Load a conversation persisted before this change (or clear the `model` field manually) — no footer is rendered.
- [ ] `npm run typecheck`, `npm run test`, `npm run biome` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Assistant messages now display which model was used to generate them beneath each response.
  * Enhanced support for OpenRouter's auto-routing mode with real-time model attribution tracking.

* **Tests**
  * Added validation tests for model attribution event emission behavior across streaming iterations.

* **Documentation**
  * Added design specification for per-message model attribution implementation and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->