### PR TITLE
ask: nine UI fixes (padding, session switching, share, graypaper link, shared cache)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,5 +9,5 @@ DISCORD_TOKEN=...
 EMBEDDINGS_ENABLED=true
 
 # Cheap model used to generate titles for Ask sessions.
-# Defaults to anthropic/claude-haiku-4-5.
-TITLE_MODEL=anthropic/claude-haiku-4-5
+# Defaults to anthropic/claude-haiku-4.5.
+TITLE_MODEL=anthropic/claude-haiku-4.5

--- a/backend/src/__tests__/ask/titleGen.test.ts
+++ b/backend/src/__tests__/ask/titleGen.test.ts
@@ -17,7 +17,7 @@ describe("generateTitle", () => {
   it("returns a trimmed, quote-free title", async () => {
     const title = await generateTitle({
       openai: fakeOpenAI('"How work results accumulate"'),
-      model: "anthropic/claude-haiku-4-5",
+      model: "anthropic/claude-haiku-4.5",
       question: "How do work results accumulate in JAM?",
     });
     expect(title).toBe("How work results accumulate");

--- a/backend/src/api/askTitle.ts
+++ b/backend/src/api/askTitle.ts
@@ -24,7 +24,7 @@ export function handleAskTitle() {
       );
     }
     const { question, openrouterKey } = parsed.data;
-    const model = process.env.TITLE_MODEL ?? "anthropic/claude-haiku-4-5";
+    const model = process.env.TITLE_MODEL ?? "anthropic/claude-haiku-4.5";
     const openai = createOpenRouterClient(openrouterKey);
     try {
       const title = await generateTitle({ openai, model, question });

--- a/backend/src/ask/tools.ts
+++ b/backend/src/ask/tools.ts
@@ -47,9 +47,14 @@ function buildMatrixUrl(
   return `${room.archiveUrl}#${messageId}`;
 }
 
-function buildGraypaperUrl(title: string | undefined): string | undefined {
+function buildGraypaperUrl(
+  title: string | undefined,
+  query: string
+): string | undefined {
   if (!title) return undefined;
-  return `https://graypaper.fluffylabs.dev/#/?section=${encodeURIComponent(title)}`;
+  // Match the search-results URL format byte-for-byte (no URL encoding).
+  // The Graypaper reader's hash router expects this exact shape.
+  return `https://graypaper.fluffylabs.dev/#/?search=${query}&section=${title}`;
 }
 
 /**
@@ -165,7 +170,7 @@ export async function executeSearchAll(
       sourceType: "graypaper",
       preview: truncate(r.text ?? ""),
       title: r.title,
-      url: buildGraypaperUrl(r.title),
+      url: buildGraypaperUrl(r.title, args.query),
       score: r.score,
     });
   }
@@ -213,7 +218,9 @@ function resolveDocUrl(doc: SearchDoc): string | undefined {
       return buildMatrixUrl(doc.roomId, doc.messageId);
     case "graypaper_section":
     case "graypaper_version":
-      return buildGraypaperUrl(doc.title);
+      // No search query context here; fall back to empty query so the
+      // reader still routes to the section.
+      return buildGraypaperUrl(doc.title, "");
   }
 }
 

--- a/client/package.json
+++ b/client/package.json
@@ -33,6 +33,7 @@
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.14.0",
     "remark-gfm": "^4.0.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",
     "tw-animate-css": "^1.4.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import { AppsSidebar } from "@fluffylabs/shared-ui";
 import { AuthCallback, AuthFlow } from "@fluffylabs/shared-ui/supabase";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { Toaster } from "sonner";
 import { AskLayout } from "@/components/ask/AskLayout";
 import { peekForkPending } from "@/lib/forkPending";
 import { EmbeddedViewer } from "./components/EmbeddedViewer";
@@ -159,6 +160,7 @@ function App() {
           </div>
         </div>
       </div>
+      <Toaster position="bottom-right" richColors closeButton />
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -92,9 +92,10 @@ function App() {
   const isUsingEmbeddedViewer = useEmbeddedViewer().isVisible;
   const navigate = useNavigate();
   const { pathname } = useLocation();
-  // /ask manages its own scroll/padding so the section/aside border can
-  // span the full available height.
-  const fullBleed = pathname === "/ask";
+  // /ask (and its nested session routes + shared view) manages its own
+  // scroll/padding so the section/aside border can span the full height
+  // and the shared page doesn't double-pad.
+  const fullBleed = pathname === "/ask" || pathname.startsWith("/ask/");
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/client/src/components/ask/AskLayout.tsx
+++ b/client/src/components/ask/AskLayout.tsx
@@ -1,4 +1,5 @@
 import { Outlet, useParams } from "react-router-dom";
+import { toast } from "sonner";
 import { AuthGate } from "@/components/ask/AuthGate";
 import { SessionsSidebar } from "@/components/ask/SessionsSidebar";
 import { useSessions } from "@/hooks/useSessions";
@@ -9,6 +10,10 @@ export function AskLayout() {
       <LayoutInner />
     </AuthGate>
   );
+}
+
+function shareUrlFor(sessionId: string): string {
+  return `${window.location.origin}${window.location.pathname}#/ask/s/${sessionId}`;
 }
 
 function LayoutInner() {
@@ -33,8 +38,22 @@ function LayoutInner() {
             sessions.remove(id);
           }
         }}
-        onShare={() => {
-          // Implemented in Task 10 (flip public + copy + toast).
+        onShare={async (id) => {
+          const session = sessions.sessions?.find((s) => s.id === id);
+          const wasPublic = session?.isPublic === true;
+          try {
+            if (!wasPublic) {
+              await sessions.update(id, { isPublic: true });
+            }
+            await navigator.clipboard.writeText(shareUrlFor(id));
+            toast.success(
+              wasPublic ? "Link copied" : "Link copied. Session is public now"
+            );
+          } catch (err) {
+            toast.error(
+              `Couldn't share: ${(err as Error).message ?? "unknown error"}`
+            );
+          }
         }}
       />
       <div className="flex-1 min-w-0">

--- a/client/src/components/ask/AskLayout.tsx
+++ b/client/src/components/ask/AskLayout.tsx
@@ -33,7 +33,9 @@ function LayoutInner() {
         }}
         onDelete={(id) => {
           if (
-            window.confirm("Delete this session? Any public link will 404.")
+            window.confirm(
+              "Delete this session? Any public link will become unavailable."
+            )
           ) {
             sessions.remove(id);
           }

--- a/client/src/components/ask/AskLayout.tsx
+++ b/client/src/components/ask/AskLayout.tsx
@@ -41,17 +41,29 @@ function LayoutInner() {
         onShare={async (id) => {
           const session = sessions.sessions?.find((s) => s.id === id);
           const wasPublic = session?.isPublic === true;
+          let madePublic = false;
           try {
             if (!wasPublic) {
               await sessions.update(id, { isPublic: true });
+              madePublic = true;
             }
-            await navigator.clipboard.writeText(shareUrlFor(id));
-            toast.success(
-              wasPublic ? "Link copied" : "Link copied. Session is public now"
-            );
           } catch (err) {
             toast.error(
               `Couldn't share: ${(err as Error).message ?? "unknown error"}`
+            );
+            return;
+          }
+          try {
+            await navigator.clipboard.writeText(shareUrlFor(id));
+            toast.success(
+              madePublic ? "Link copied. Session is public now" : "Link copied"
+            );
+          } catch (err) {
+            const reason = (err as Error).message ?? "unknown error";
+            toast.error(
+              madePublic
+                ? `Couldn't copy link — session is public now: ${reason}`
+                : `Couldn't copy link: ${reason}`
             );
           }
         }}

--- a/client/src/components/ask/AskLayout.tsx
+++ b/client/src/components/ask/AskLayout.tsx
@@ -1,9 +1,7 @@
-import { useUserData } from "@fluffylabs/shared-ui/supabase";
 import { Outlet, useParams } from "react-router-dom";
 import { AuthGate } from "@/components/ask/AuthGate";
 import { SessionsSidebar } from "@/components/ask/SessionsSidebar";
 import { useSessions } from "@/hooks/useSessions";
-import { requestTitle } from "@/lib/askTitleClient";
 
 export function AskLayout() {
   return (
@@ -16,10 +14,6 @@ export function AskLayout() {
 function LayoutInner() {
   const { sessionId } = useParams<{ sessionId?: string }>();
   const sessions = useSessions();
-  const { data: keyData } = useUserData("openrouter-api-key", {
-    appScoped: true,
-  });
-  const apiKey = typeof keyData === "string" ? keyData : null;
 
   return (
     <div className="flex h-full">
@@ -39,22 +33,8 @@ function LayoutInner() {
             sessions.remove(id);
           }
         }}
-        onToggleShare={(id, next) => sessions.update(id, { isPublic: next })}
-        onRegenerateTitle={async (id) => {
-          if (!apiKey) {
-            window.alert(
-              "Add an OpenRouter API key in Settings before regenerating titles."
-            );
-            return;
-          }
-          const record = await sessions.get(id);
-          const first = record?.state.messages.find((m) => m.role === "user");
-          if (!first || first.role !== "user") return;
-          const title = await requestTitle({
-            question: first.content,
-            openrouterKey: apiKey,
-          });
-          if (title) await sessions.update(id, { title });
+        onShare={() => {
+          // Implemented in Task 10 (flip public + copy + toast).
         }}
       />
       <div className="flex-1 min-w-0">

--- a/client/src/components/ask/SessionRow.tsx
+++ b/client/src/components/ask/SessionRow.tsx
@@ -14,33 +14,31 @@ export function SessionRow({
   active,
   onRename,
   onDelete,
-  onToggleShare,
-  onRegenerateTitle,
+  onShare,
 }: {
   session: AskSessionSummary;
   active: boolean;
   onRename: (id: string) => void;
   onDelete: (id: string) => void;
-  onToggleShare: (id: string, next: boolean) => void;
-  onRegenerateTitle: (id: string) => void;
+  onShare: (id: string) => void;
 }) {
   return (
     <div
       className={cn(
-        "group flex items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-accent",
+        "group flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground hover:bg-accent",
         active && "bg-accent"
       )}
     >
       <Link
         to={`/ask/${session.id}`}
-        className="flex-1 min-w-0 truncate"
+        className="flex-1 min-w-0 truncate text-foreground"
         title={session.title ?? "Untitled"}
       >
         {session.title ?? "Untitled"}
       </Link>
       <DropdownMenu>
         <DropdownMenuTrigger
-          className="opacity-0 group-hover:opacity-100 focus:opacity-100"
+          className="opacity-0 group-hover:opacity-100 focus:opacity-100 text-muted-foreground hover:text-foreground"
           aria-label="Session actions"
         >
           <MoreHorizontal className="size-4" />
@@ -49,16 +47,11 @@ export function SessionRow({
           <DropdownMenuItem onClick={() => onRename(session.id)}>
             Rename
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => onRegenerateTitle(session.id)}>
-            Regenerate title
+          <DropdownMenuItem onClick={() => onShare(session.id)}>
+            Share…
           </DropdownMenuItem>
           <DropdownMenuItem
-            onClick={() => onToggleShare(session.id, !session.isPublic)}
-          >
-            {session.isPublic ? "Unshare" : "Share…"}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            className="text-destructive"
+            className="text-destructive focus:text-destructive"
             onClick={() => onDelete(session.id)}
           >
             Delete

--- a/client/src/components/ask/SessionRow.tsx
+++ b/client/src/components/ask/SessionRow.tsx
@@ -4,6 +4,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { AskSessionSummary } from "@/lib/sessionTypes";
@@ -43,15 +45,26 @@ export function SessionRow({
         >
           <MoreHorizontal className="size-4" />
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end">
-          <DropdownMenuItem onClick={() => onRename(session.id)}>
+        <DropdownMenuContent align="end" className="min-w-[12rem]">
+          <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+            Session
+          </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onClick={() => onRename(session.id)}
+          >
             Rename
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => onShare(session.id)}>
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onClick={() => onShare(session.id)}
+          >
             Share…
           </DropdownMenuItem>
+          <DropdownMenuSeparator />
           <DropdownMenuItem
-            className="text-destructive focus:text-destructive"
+            className="cursor-pointer text-destructive focus:text-destructive"
             onClick={() => onDelete(session.id)}
           >
             Delete

--- a/client/src/components/ask/SessionRow.tsx
+++ b/client/src/components/ask/SessionRow.tsx
@@ -33,10 +33,7 @@ export function SessionRow({
     >
       <Link
         to={`/ask/${session.id}`}
-        className={cn(
-          "flex-1 min-w-0 truncate",
-          active ? "font-medium" : "font-light"
-        )}
+        className="flex-1 min-w-0 truncate"
         title={session.title ?? "Untitled"}
       >
         {session.title ?? "Untitled"}
@@ -48,8 +45,8 @@ export function SessionRow({
         >
           <MoreHorizontal className="size-4" />
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="min-w-[12rem]">
-          <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+        <DropdownMenuContent align="end" className="min-w-[12rem] font-light">
+          <DropdownMenuLabel className="text-xs text-muted-foreground">
             Session
           </DropdownMenuLabel>
           <DropdownMenuSeparator />

--- a/client/src/components/ask/SessionRow.tsx
+++ b/client/src/components/ask/SessionRow.tsx
@@ -27,13 +27,16 @@ export function SessionRow({
   return (
     <div
       className={cn(
-        "group flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground hover:bg-accent",
-        active && "bg-accent"
+        "group flex items-center gap-2 rounded-md px-2 py-1 text-xs hover:bg-accent",
+        active ? "text-foreground bg-accent" : "text-muted-foreground"
       )}
     >
       <Link
         to={`/ask/${session.id}`}
-        className="flex-1 min-w-0 truncate text-foreground"
+        className={cn(
+          "flex-1 min-w-0 truncate",
+          active ? "font-medium" : "font-light"
+        )}
         title={session.title ?? "Untitled"}
       >
         {session.title ?? "Untitled"}

--- a/client/src/components/ask/SessionsSidebar.tsx
+++ b/client/src/components/ask/SessionsSidebar.tsx
@@ -33,7 +33,7 @@ export function SessionsSidebar({
   const groups = useMemo(() => groupSessions(filtered, now), [filtered, now]);
 
   return (
-    <aside className="flex w-64 shrink-0 flex-col border-r-1 border-r-[#D4D4D4] dark:border-r-[#181818] bg-card/50 text-foreground">
+    <aside className="flex w-64 shrink-0 flex-col border-r-1 border-r-[#D4D4D4] dark:border-r-[#181818] bg-card/50 text-foreground font-light">
       {/* Fixed "Search" header — matches the main section and sources aside
           heights so the horizontal line under all three columns aligns. The
           bottom border is the "shadow" half of the shared 3D bevel; the
@@ -54,7 +54,12 @@ export function SessionsSidebar({
         </div>
       </div>
       <div className="shrink-0 p-2 border-t-1 border-t-white dark:border-t-[#353535] border-b-1 border-b-[#D4D4D4] dark:border-b-[#181818]">
-        <Button asChild size="sm" variant="outline" className="w-full gap-1.5">
+        <Button
+          asChild
+          size="sm"
+          variant="outline"
+          className="w-full gap-1.5 font-light"
+        >
           <Link to="/ask">
             <Plus className="size-4" />
             New chat
@@ -64,7 +69,7 @@ export function SessionsSidebar({
       <div className="flex-1 overflow-y-auto px-2 pb-2 border-t-1 border-t-white dark:border-t-[#353535]">
         {groups.map((group) => (
           <div key={group.label} className="mb-3">
-            <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+            <div className="px-2 py-1 text-[10px] uppercase tracking-wider text-muted-foreground">
               {group.label}
             </div>
             {group.sessions.map((s) => (

--- a/client/src/components/ask/SessionsSidebar.tsx
+++ b/client/src/components/ask/SessionsSidebar.tsx
@@ -13,16 +13,14 @@ export function SessionsSidebar({
   now,
   onRename,
   onDelete,
-  onToggleShare,
-  onRegenerateTitle,
+  onShare,
 }: {
   sessions: AskSessionSummary[];
   activeId: string | null;
   now?: Date;
   onRename: (id: string) => void;
   onDelete: (id: string) => void;
-  onToggleShare: (id: string, next: boolean) => void;
-  onRegenerateTitle: (id: string) => void;
+  onShare: (id: string) => void;
 }) {
   const [filter, setFilter] = useState("");
   const filtered = useMemo(() => {
@@ -35,7 +33,7 @@ export function SessionsSidebar({
   const groups = useMemo(() => groupSessions(filtered, now), [filtered, now]);
 
   return (
-    <aside className="flex w-64 shrink-0 flex-col border-r border-border bg-card/50">
+    <aside className="flex w-64 shrink-0 flex-col border-r border-border bg-card/50 text-foreground">
       <div className="p-2">
         <Button asChild size="sm" variant="outline" className="w-full">
           <Link to="/ask">
@@ -64,8 +62,7 @@ export function SessionsSidebar({
                 active={s.id === activeId}
                 onRename={onRename}
                 onDelete={onDelete}
-                onToggleShare={onToggleShare}
-                onRegenerateTitle={onRegenerateTitle}
+                onShare={onShare}
               />
             ))}
           </div>

--- a/client/src/components/ask/SessionsSidebar.tsx
+++ b/client/src/components/ask/SessionsSidebar.tsx
@@ -35,10 +35,10 @@ export function SessionsSidebar({
   return (
     <aside className="flex w-64 shrink-0 flex-col border-r-1 border-r-[#D4D4D4] dark:border-r-[#181818] bg-card/50 text-foreground font-light">
       {/* Fixed "Search" header — matches the main section and sources aside
-          heights so the horizontal line under all three columns aligns. The
-          bottom border is the "shadow" half of the shared 3D bevel; the
-          matching "highlight" border lives on the next element. */}
-      <div className="h-12 shrink-0 border-b-1 border-b-[#D4D4D4] dark:border-b-[#181818] px-2 flex items-center">
+          heights so the horizontal line under all three columns aligns.
+          Muted divider: only the light highlight line on the next row, no
+          dark shadow on this header's bottom. */}
+      <div className="h-12 shrink-0 px-2 flex items-center">
         <div className="relative flex-1">
           <Search
             className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground"
@@ -53,7 +53,7 @@ export function SessionsSidebar({
           />
         </div>
       </div>
-      <div className="shrink-0 p-2 border-t-1 border-t-white dark:border-t-[#353535] border-b-1 border-b-[#D4D4D4] dark:border-b-[#181818]">
+      <div className="shrink-0 p-2 border-t-1 border-t-white dark:border-t-[#353535]">
         <Button
           asChild
           size="sm"
@@ -66,7 +66,9 @@ export function SessionsSidebar({
           </Link>
         </Button>
       </div>
-      <div className="flex-1 overflow-y-auto px-2 pb-2 border-t-1 border-t-white dark:border-t-[#353535]">
+      {/* No border between "New chat" and the session list — they read as
+          one continuous block. */}
+      <div className="flex-1 overflow-y-auto px-2 pb-2">
         {groups.map((group) => (
           <div key={group.label} className="mb-3">
             <div className="px-2 py-1 text-[10px] uppercase tracking-wider text-muted-foreground">

--- a/client/src/components/ask/SessionsSidebar.tsx
+++ b/client/src/components/ask/SessionsSidebar.tsx
@@ -33,10 +33,12 @@ export function SessionsSidebar({
   const groups = useMemo(() => groupSessions(filtered, now), [filtered, now]);
 
   return (
-    <aside className="flex w-64 shrink-0 flex-col border-r border-border bg-card/50 text-foreground">
+    <aside className="flex w-64 shrink-0 flex-col border-r-1 border-r-[#D4D4D4] dark:border-r-[#181818] bg-card/50 text-foreground">
       {/* Fixed "Search" header — matches the main section and sources aside
-          heights so the horizontal line under all three columns aligns. */}
-      <div className="h-12 shrink-0 border-b border-border/60 px-2 flex items-center">
+          heights so the horizontal line under all three columns aligns. The
+          bottom border is the "shadow" half of the shared 3D bevel; the
+          matching "highlight" border lives on the next element. */}
+      <div className="h-12 shrink-0 border-b-1 border-b-[#D4D4D4] dark:border-b-[#181818] px-2 flex items-center">
         <div className="relative flex-1">
           <Search
             className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground"
@@ -51,7 +53,7 @@ export function SessionsSidebar({
           />
         </div>
       </div>
-      <div className="shrink-0 p-2">
+      <div className="shrink-0 p-2 border-t-1 border-t-white dark:border-t-[#353535] border-b-1 border-b-[#D4D4D4] dark:border-b-[#181818]">
         <Button asChild size="sm" variant="outline" className="w-full gap-1.5">
           <Link to="/ask">
             <Plus className="size-4" />
@@ -59,7 +61,7 @@ export function SessionsSidebar({
           </Link>
         </Button>
       </div>
-      <div className="flex-1 overflow-y-auto px-2 pb-2">
+      <div className="flex-1 overflow-y-auto px-2 pb-2 border-t-1 border-t-white dark:border-t-[#353535]">
         {groups.map((group) => (
           <div key={group.label} className="mb-3">
             <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">

--- a/client/src/components/ask/SessionsSidebar.tsx
+++ b/client/src/components/ask/SessionsSidebar.tsx
@@ -1,4 +1,4 @@
-import { Plus } from "lucide-react";
+import { Plus, Search } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { SessionRow } from "@/components/ask/SessionRow";
@@ -34,25 +34,35 @@ export function SessionsSidebar({
 
   return (
     <aside className="flex w-64 shrink-0 flex-col border-r border-border bg-card/50 text-foreground">
-      <div className="p-2">
-        <Button asChild size="sm" variant="outline" className="w-full">
+      {/* Fixed "Search" header — matches the main section and sources aside
+          heights so the horizontal line under all three columns aligns. */}
+      <div className="h-12 shrink-0 border-b border-border/60 px-2 flex items-center">
+        <div className="relative flex-1">
+          <Search
+            className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <Input
+            placeholder="Search"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            aria-label="Search sessions"
+            className="h-8 pl-7 text-xs"
+          />
+        </div>
+      </div>
+      <div className="shrink-0 p-2">
+        <Button asChild size="sm" variant="outline" className="w-full gap-1.5">
           <Link to="/ask">
-            <Plus className="size-4" /> New chat
+            <Plus className="size-4" />
+            New chat
           </Link>
         </Button>
-      </div>
-      <div className="px-2 pb-2">
-        <Input
-          placeholder="Filter…"
-          value={filter}
-          onChange={(e) => setFilter(e.target.value)}
-          aria-label="Filter sessions"
-        />
       </div>
       <div className="flex-1 overflow-y-auto px-2 pb-2">
         {groups.map((group) => (
           <div key={group.label} className="mb-3">
-            <div className="px-2 py-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
               {group.label}
             </div>
             {group.sessions.map((s) => (
@@ -68,7 +78,7 @@ export function SessionsSidebar({
           </div>
         ))}
         {filtered.length === 0 && (
-          <div className="p-4 text-center text-sm text-muted-foreground">
+          <div className="p-4 text-center text-xs text-muted-foreground">
             {sessions.length === 0 ? "No sessions yet." : "No matches."}
           </div>
         )}

--- a/client/src/components/ask/SharePopover.tsx
+++ b/client/src/components/ask/SharePopover.tsx
@@ -22,9 +22,9 @@ export function SharePopover({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant="outline" size="sm">
+        <Button variant="outline" size="sm" className="gap-1.5">
           <Share2 className="size-4" />
-          {isPublic ? "Shared" : "Share"}
+          {isPublic ? "Public" : "Share"}
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-80">

--- a/client/src/components/ask/SharePopover.tsx
+++ b/client/src/components/ask/SharePopover.tsx
@@ -67,7 +67,7 @@ export function SharePopover({
         </div>
         {!isPublic && (
           <p className="mt-2 text-xs text-muted-foreground">
-            Off — anyone with the link will see a 404.
+            Off — anyone with the link will see it as unavailable.
           </p>
         )}
         {copied && (

--- a/client/src/components/ask/SharePopover.tsx
+++ b/client/src/components/ask/SharePopover.tsx
@@ -45,27 +45,28 @@ export function SharePopover({
             }}
           />
         </div>
-        <div className="mt-3 flex items-center gap-2">
-          <Input
-            readOnly
-            value={url}
-            onFocus={(e) => e.currentTarget.select()}
-            className={isPublic ? "" : "opacity-60"}
-          />
-          <Button
-            size="icon"
-            variant="outline"
-            aria-label="Copy link"
-            onClick={async () => {
-              await navigator.clipboard.writeText(url);
-              setCopied(true);
-              setTimeout(() => setCopied(false), 1500);
-            }}
-          >
-            <Copy className="size-4" />
-          </Button>
-        </div>
-        {!isPublic && (
+        {isPublic ? (
+          <div className="mt-3 flex items-center gap-2">
+            <Input
+              readOnly
+              value={url}
+              onFocus={(e) => e.currentTarget.select()}
+              className="text-xs"
+            />
+            <Button
+              size="icon"
+              variant="outline"
+              aria-label="Copy link"
+              onClick={async () => {
+                await navigator.clipboard.writeText(url);
+                setCopied(true);
+                setTimeout(() => setCopied(false), 1500);
+              }}
+            >
+              <Copy className="size-4" />
+            </Button>
+          </div>
+        ) : (
           <p className="mt-2 text-xs text-muted-foreground">
             Off — anyone with the link will see it as unavailable.
           </p>

--- a/client/src/components/ask/SharePopover.tsx
+++ b/client/src/components/ask/SharePopover.tsx
@@ -22,7 +22,7 @@ export function SharePopover({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant="outline" size="sm" className="gap-1.5">
+        <Button variant="outline" size="sm" className="gap-1.5 font-light">
           <Share2 className="size-4" />
           {isPublic ? "Public" : "Share"}
         </Button>

--- a/client/src/components/ask/__tests__/SessionsSidebar.test.tsx
+++ b/client/src/components/ask/__tests__/SessionsSidebar.test.tsx
@@ -48,7 +48,7 @@ describe("SessionsSidebar", () => {
 
   it("filter input narrows the list case-insensitively", async () => {
     renderSidebar(sessions);
-    await userEvent.type(screen.getByLabelText(/filter/i), "yesterday");
+    await userEvent.type(screen.getByLabelText(/search/i), "yesterday");
     expect(screen.queryByText("Today session")).not.toBeInTheDocument();
     expect(screen.getByText("Yesterday session")).toBeInTheDocument();
   });

--- a/client/src/components/ask/__tests__/SessionsSidebar.test.tsx
+++ b/client/src/components/ask/__tests__/SessionsSidebar.test.tsx
@@ -26,8 +26,7 @@ function renderSidebar(sessions: AskSessionSummary[]) {
         now={new Date("2026-04-23T12:00:00Z")}
         onRename={vi.fn()}
         onDelete={vi.fn()}
-        onToggleShare={vi.fn()}
-        onRegenerateTitle={vi.fn()}
+        onShare={vi.fn()}
       />
     </MemoryRouter>
   );

--- a/client/src/components/chat/ChatInput.tsx
+++ b/client/src/components/chat/ChatInput.tsx
@@ -90,7 +90,12 @@ export function ChatInput({
         </span>
         <div className="flex items-center gap-2 ml-auto">
           <ModelPicker value={model} onChange={onModelChange} />
-          <Button onClick={submit} disabled={!ready} size="sm">
+          <Button
+            onClick={submit}
+            disabled={!ready}
+            size="sm"
+            className="font-light"
+          >
             Ask
           </Button>
         </div>

--- a/client/src/components/chat/CitationCard.tsx
+++ b/client/src/components/chat/CitationCard.tsx
@@ -15,7 +15,7 @@ export function CitationCard({ citation, card }: CitationCardProps) {
 
   const header = (
     <div className="flex items-center gap-2 min-w-0 w-full">
-      <span className="inline-flex items-center justify-center min-w-[1.5rem] h-5 px-1.5 rounded bg-brand-light text-brand-dark text-[11px] font-medium tabular-nums shrink-0">
+      <span className="inline-flex items-center justify-center min-w-[1.5rem] h-5 px-1.5 rounded bg-brand-light text-brand-dark text-[11px] tabular-nums shrink-0">
         {citation.n}
       </span>
       <span className="inline-flex items-center gap-1.5 text-[10px] uppercase tracking-wide text-muted-foreground shrink-0">
@@ -25,7 +25,7 @@ export function CitationCard({ citation, card }: CitationCardProps) {
         />
         {sourceLabel(citation.sourceType)}
       </span>
-      <span className="flex-1 min-w-0 truncate font-medium text-foreground text-xs">
+      <span className="flex-1 min-w-0 truncate text-foreground text-xs">
         {renderTitle(citation, card)}
       </span>
       {iso && (

--- a/client/src/components/chat/CitationsPanel.tsx
+++ b/client/src/components/chat/CitationsPanel.tsx
@@ -9,26 +9,19 @@ interface CitationsPanelProps {
 export function CitationsPanel({ assistant, cards }: CitationsPanelProps) {
   const citations = assistant?.citations ?? [];
 
-  return (
-    <div className="flex flex-col gap-4">
-      <div className="flex items-baseline justify-between">
-        <h3 className="text-sm font-semibold text-foreground">Sources</h3>
-        <span className="text-xs text-muted-foreground tabular-nums">
-          {citations.length}
-        </span>
-      </div>
+  if (citations.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Sources will appear here as the agent cites them.
+      </p>
+    );
+  }
 
-      {citations.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          Sources will appear here as the agent cites them.
-        </p>
-      ) : (
-        <div className="flex flex-col gap-3">
-          {citations.map((c) => (
-            <CitationCard key={c.n} citation={c} card={cards[c.docId]} />
-          ))}
-        </div>
-      )}
+  return (
+    <div className="flex flex-col gap-3">
+      {citations.map((c) => (
+        <CitationCard key={c.n} citation={c} card={cards[c.docId]} />
+      ))}
     </div>
   );
 }

--- a/client/src/components/chat/Markdown.tsx
+++ b/client/src/components/chat/Markdown.tsx
@@ -34,12 +34,13 @@ export function Markdown({ content, onCitationClick }: MarkdownProps) {
 // Base styles for all block/inline markdown elements. Scoped via a single
 // wrapper div so we don't pollute other prose in the app.
 const markdownStyles = cn(
-  "text-[15px] leading-7 text-foreground",
-  // Headings
-  "[&_h1]:text-xl [&_h1]:font-semibold [&_h1]:mt-5 [&_h1]:mb-3",
-  "[&_h2]:text-lg [&_h2]:font-semibold [&_h2]:mt-5 [&_h2]:mb-2",
-  "[&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-4 [&_h3]:mb-2",
-  "[&_h4]:text-sm [&_h4]:font-semibold [&_h4]:mt-3 [&_h4]:mb-1.5",
+  "text-[15px] leading-7 text-foreground font-light",
+  // Headings — one step heavier than the font-light body so they still read
+  // as headings without jumping to a semibold contrast.
+  "[&_h1]:text-xl [&_h1]:font-normal [&_h1]:mt-5 [&_h1]:mb-3",
+  "[&_h2]:text-lg [&_h2]:font-normal [&_h2]:mt-5 [&_h2]:mb-2",
+  "[&_h3]:text-base [&_h3]:font-normal [&_h3]:mt-4 [&_h3]:mb-2",
+  "[&_h4]:text-sm [&_h4]:font-normal [&_h4]:mt-3 [&_h4]:mb-1.5",
   // Paragraphs and spacing
   "[&_p]:my-3 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0",
   // Lists
@@ -48,7 +49,7 @@ const markdownStyles = cn(
   "[&_li]:my-1",
   "[&_li>ul]:my-1 [&_li>ol]:my-1",
   // Inline text
-  "[&_strong]:font-semibold [&_em]:italic",
+  "[&_strong]:font-normal [&_em]:italic",
   "[&_a]:text-brand-dark [&_a]:underline [&_a]:underline-offset-2 hover:[&_a]:opacity-80",
   // Code
   "[&_code]:font-mono [&_code]:text-[0.9em] [&_:not(pre)>code]:bg-muted [&_:not(pre)>code]:px-1 [&_:not(pre)>code]:py-0.5 [&_:not(pre)>code]:rounded",
@@ -59,7 +60,7 @@ const markdownStyles = cn(
   // Tables (via remark-gfm)
   "[&_table]:w-full [&_table]:my-4 [&_table]:border-collapse [&_table]:text-sm",
   "[&_thead]:border-b [&_thead]:border-border",
-  "[&_th]:text-left [&_th]:font-semibold [&_th]:px-3 [&_th]:py-2 [&_th]:align-top",
+  "[&_th]:text-left [&_th]:font-normal [&_th]:px-3 [&_th]:py-2 [&_th]:align-top",
   "[&_td]:px-3 [&_td]:py-2 [&_td]:align-top [&_td]:border-t [&_td]:border-border/60",
   // Horizontal rule
   "[&_hr]:my-4 [&_hr]:border-border",
@@ -89,7 +90,7 @@ function makeComponents(onCitationClick: (n: number) => void): Components {
           onClick={() => onCitationClick(n)}
           className={cn(
             "inline-flex items-center justify-center min-w-[1.5rem] h-5 px-1 mx-0.5",
-            "rounded text-[11px] font-medium tabular-nums align-middle",
+            "rounded text-[11px] tabular-nums align-middle",
             "bg-brand-light text-brand-dark",
             "hover:bg-brand hover:text-white transition-colors"
           )}

--- a/client/src/components/chat/ModelPicker.tsx
+++ b/client/src/components/chat/ModelPicker.tsx
@@ -33,18 +33,14 @@ export function ModelPicker({ value, onChange }: ModelPickerProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="sm" className="gap-1.5">
-          <span className="text-xs text-muted-foreground font-normal">
-            Model
-          </span>
-          <span className="text-xs text-muted-foreground font-normal">
-            {current.label}
-          </span>
+        <Button variant="outline" size="sm" className="gap-1.5 font-light">
+          <span className="text-xs text-muted-foreground">Model</span>
+          <span className="text-xs text-muted-foreground">{current.label}</span>
           <span className="text-muted-foreground">▾</span>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="min-w-[18rem]">
-        <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+      <DropdownMenuContent align="start" className="min-w-[18rem] font-light">
+        <DropdownMenuLabel className="text-xs text-muted-foreground">
           OpenRouter model
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
@@ -52,7 +48,7 @@ export function ModelPicker({ value, onChange }: ModelPickerProps) {
           <Fragment key={group.tier ?? "untagged"}>
             {idx > 0 && <DropdownMenuSeparator />}
             {group.tier && (
-              <DropdownMenuLabel className="text-[10px] uppercase tracking-wide font-normal text-muted-foreground/70">
+              <DropdownMenuLabel className="text-[10px] uppercase tracking-wide text-muted-foreground/70">
                 {TIER_LABEL[group.tier]}
               </DropdownMenuLabel>
             )}
@@ -62,8 +58,7 @@ export function ModelPicker({ value, onChange }: ModelPickerProps) {
                 onSelect={() => onChange(m.id)}
                 className={cn(
                   "cursor-pointer",
-                  m.id === value &&
-                    "font-medium text-brand-dark dark:text-brand"
+                  m.id === value && "text-brand-dark dark:text-brand"
                 )}
               >
                 <span className="w-3 text-brand-dark dark:text-brand">

--- a/client/src/components/chat/ModelPicker.tsx
+++ b/client/src/components/chat/ModelPicker.tsx
@@ -37,7 +37,9 @@ export function ModelPicker({ value, onChange }: ModelPickerProps) {
           <span className="text-xs text-muted-foreground font-normal">
             Model
           </span>
-          <span className="font-medium">{current.label}</span>
+          <span className="text-xs text-muted-foreground font-normal">
+            {current.label}
+          </span>
           <span className="text-muted-foreground">▾</span>
         </Button>
       </DropdownMenuTrigger>

--- a/client/src/components/chat/ToolStep.tsx
+++ b/client/src/components/chat/ToolStep.tsx
@@ -37,9 +37,7 @@ export function ToolStep({ step, isActive = false }: ToolStepProps) {
                 : "bg-brand-dark/50"
           )}
         />
-        <span className="font-medium text-foreground/80 shrink-0">
-          {step.toolName}
-        </span>
+        <span className="text-foreground/80 shrink-0">{step.toolName}</span>
         {preview && (
           <span className="truncate text-muted-foreground">{preview}</span>
         )}

--- a/client/src/components/ui/dropdown-menu.tsx
+++ b/client/src/components/ui/dropdown-menu.tsx
@@ -45,7 +45,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border border-border/40 bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -63,7 +63,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-border/40 bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className
       )}
       {...props}

--- a/client/src/hooks/__tests__/useSessions.test.ts
+++ b/client/src/hooks/__tests__/useSessions.test.ts
@@ -151,6 +151,10 @@ describe("useSessions", () => {
     });
 
     // Both hooks should have triggered a refetch via the shared cache.
-    await waitFor(() => expect(builder.order).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(a.result.current.sessions).toBeDefined();
+      expect(b.result.current.sessions).toBeDefined();
+      expect(builder.order).toHaveBeenCalled();
+    });
   });
 });

--- a/client/src/hooks/__tests__/useSessions.test.ts
+++ b/client/src/hooks/__tests__/useSessions.test.ts
@@ -43,11 +43,7 @@ function wrapperFactory() {
     },
   });
   const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
-    React.createElement(
-      QueryClientProvider,
-      { client: queryClient },
-      children
-    );
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
   return { wrapper: Wrapper, queryClient };
 }
 

--- a/client/src/hooks/__tests__/useSessions.test.ts
+++ b/client/src/hooks/__tests__/useSessions.test.ts
@@ -1,4 +1,6 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { createUseSessions } from "@/hooks/useSessions";
 
@@ -33,12 +35,31 @@ function makeClient(rows: unknown[] = []) {
   return { client: { from }, from, builder };
 }
 
+function wrapperFactory() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children
+    );
+  return { wrapper: Wrapper, queryClient };
+}
+
 describe("useSessions", () => {
   it("list() queries ask_sessions ordered by updated_at desc for the user", async () => {
     const { client, from, builder } = makeClient([]);
-    const hook = renderHook(() =>
-      createUseSessions({ supabase: client as never, userId: "u1" })()
-    );
+    const { wrapper } = wrapperFactory();
+    const useHook = createUseSessions({
+      supabase: client as never,
+      userId: "u1",
+    });
+    const hook = renderHook(() => useHook(), { wrapper });
     await waitFor(() =>
       expect(hook.result.current.sessions).not.toBeUndefined()
     );
@@ -52,11 +73,12 @@ describe("useSessions", () => {
 
   it("create() inserts a row with toRow()-shaped payload", async () => {
     const { client, builder } = makeClient();
+    const { wrapper } = wrapperFactory();
     const useHook = createUseSessions({
       supabase: client as never,
       userId: "u1",
     });
-    const hook = renderHook(() => useHook());
+    const hook = renderHook(() => useHook(), { wrapper });
     await hook.result.current.create({
       id: "11111111-1111-1111-1111-111111111111",
       title: "Hello",
@@ -79,11 +101,12 @@ describe("useSessions", () => {
 
   it("update(id, {isPublic}) sends is_public patch", async () => {
     const { client, builder } = makeClient();
+    const { wrapper } = wrapperFactory();
     const useHook = createUseSessions({
       supabase: client as never,
       userId: "u1",
     });
-    const hook = renderHook(() => useHook());
+    const hook = renderHook(() => useHook(), { wrapper });
     await hook.result.current.update("abc", { isPublic: true });
     expect(builder.update).toHaveBeenCalledWith(
       expect.objectContaining({ is_public: true })
@@ -93,13 +116,41 @@ describe("useSessions", () => {
 
   it("remove() deletes by id", async () => {
     const { client, builder } = makeClient();
+    const { wrapper } = wrapperFactory();
     const useHook = createUseSessions({
       supabase: client as never,
       userId: "u1",
     });
-    const hook = renderHook(() => useHook());
+    const hook = renderHook(() => useHook(), { wrapper });
     await hook.result.current.remove("abc");
     expect(builder.delete).toHaveBeenCalled();
     expect(builder.eq).toHaveBeenCalledWith("id", "abc");
+  });
+
+  it("mutations invalidate the shared sessions query (both consumers see the update)", async () => {
+    // Two renderHook calls sharing a QueryClient simulate AskLayout + AskPage.
+    const { client, builder } = makeClient([]);
+    const { wrapper } = wrapperFactory();
+    const useHook = createUseSessions({
+      supabase: client as never,
+      userId: "u1",
+    });
+    const a = renderHook(() => useHook(), { wrapper });
+    const b = renderHook(() => useHook(), { wrapper });
+
+    await waitFor(() => expect(a.result.current.sessions).not.toBeUndefined());
+    await waitFor(() => expect(b.result.current.sessions).not.toBeUndefined());
+
+    // Reset call counts from the initial load.
+    builder.order.mockClear();
+
+    await a.result.current.create({
+      id: "11111111-1111-1111-1111-111111111111",
+      title: "Hello",
+      state: { model: "m", cards: {}, messages: [] },
+    });
+
+    // Both hooks should have triggered a refetch via the shared cache.
+    await waitFor(() => expect(builder.order).toHaveBeenCalled());
   });
 });

--- a/client/src/hooks/__tests__/useSessions.test.ts
+++ b/client/src/hooks/__tests__/useSessions.test.ts
@@ -153,4 +153,129 @@ describe("useSessions", () => {
       expect(builder.order).toHaveBeenCalled();
     });
   });
+
+  it("create() optimistically inserts the new row into the cache before refetch", async () => {
+    const { client, builder } = makeClient([]);
+    const { wrapper } = wrapperFactory();
+    const useHook = createUseSessions({
+      supabase: client as never,
+      userId: "u1",
+    });
+    const hook = renderHook(() => useHook(), { wrapper });
+    await waitFor(() =>
+      expect(hook.result.current.sessions).not.toBeUndefined()
+    );
+    // Freeze refetch — refetch calls builder.order(), which we want
+    // never to return, so we can observe the optimistic insert alone.
+    builder.order.mockImplementation(() => new Promise(() => {}));
+
+    await hook.result.current.create({
+      id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      title: "Fresh chat",
+      state: { model: "m", cards: {}, messages: [] },
+    });
+
+    // Optimistic cache entry appears without waiting for the refetch.
+    await waitFor(() =>
+      expect(hook.result.current.sessions?.[0]).toEqual(
+        expect.objectContaining({
+          id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+          title: "Fresh chat",
+          isPublic: false,
+          model: "m",
+          userId: "u1",
+        })
+      )
+    );
+  });
+
+  it("update({state}) does NOT invalidate the sessions query (autosave loop guard)", async () => {
+    // The autosave path fires sessions.update(id, {state}) on a 100ms
+    // debounce. If that invalidated the list query, the resulting
+    // refetch would render back into the save effect and reschedule
+    // the timer in perpetuity. State-only updates must be silent.
+    const { client, builder } = makeClient([]);
+    const { wrapper } = wrapperFactory();
+    const useHook = createUseSessions({
+      supabase: client as never,
+      userId: "u1",
+    });
+    const hook = renderHook(() => useHook(), { wrapper });
+    await waitFor(() =>
+      expect(hook.result.current.sessions).not.toBeUndefined()
+    );
+    // After the initial load, no further `order()` calls should occur.
+    builder.order.mockClear();
+
+    await hook.result.current.update("abc", {
+      state: { model: "m", cards: {}, messages: [] },
+    });
+
+    // Wait a tick in case an unwanted invalidation is queued.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(builder.order).not.toHaveBeenCalled();
+  });
+
+  it("update({title}) invalidates the sessions query and patches the cache", async () => {
+    const existing = {
+      id: "abc",
+      user_id: "u1",
+      title: "Old",
+      is_public: false,
+      model: "m",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+    const { client, builder } = makeClient([existing]);
+    const { wrapper } = wrapperFactory();
+    const useHook = createUseSessions({
+      supabase: client as never,
+      userId: "u1",
+    });
+    const hook = renderHook(() => useHook(), { wrapper });
+    await waitFor(() =>
+      expect(hook.result.current.sessions?.[0]?.title).toBe("Old")
+    );
+    // After the initial load, freeze the refetch so the stale mock data
+    // doesn't overwrite our optimistic patch before we can assert on it.
+    // (A real refetch would return the updated row and the optimistic
+    //  patch would match what comes back.)
+    builder.order.mockClear();
+    builder.order.mockImplementation(() => new Promise(() => {}));
+
+    await hook.result.current.update("abc", { title: "New" });
+
+    // Optimistic title patch visible immediately.
+    await waitFor(() =>
+      expect(hook.result.current.sessions?.[0]?.title).toBe("New")
+    );
+    // And a refetch was triggered.
+    expect(builder.order).toHaveBeenCalled();
+  });
+
+  it("remove() optimistically drops the row from the cache", async () => {
+    const existing = {
+      id: "abc",
+      user_id: "u1",
+      title: "Old",
+      is_public: false,
+      model: "m",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    };
+    const { client, builder } = makeClient([existing]);
+    const { wrapper } = wrapperFactory();
+    const useHook = createUseSessions({
+      supabase: client as never,
+      userId: "u1",
+    });
+    const hook = renderHook(() => useHook(), { wrapper });
+    await waitFor(() => expect(hook.result.current.sessions).toHaveLength(1));
+    // Freeze refetch to isolate the optimistic step.
+    builder.order.mockImplementation(() => new Promise(() => {}));
+
+    await hook.result.current.remove("abc");
+
+    await waitFor(() => expect(hook.result.current.sessions).toEqual([]));
+  });
 });

--- a/client/src/hooks/useSessions.ts
+++ b/client/src/hooks/useSessions.ts
@@ -123,7 +123,22 @@ export function createUseSessions(deps: {
         const { error } = await supabase.from("ask_sessions").insert(row);
         if (error) throw new Error(error.message);
       },
-      onSuccess: () => {
+      onSuccess: (_data, args) => {
+        // Optimistic insert: put the new row at the top of the cached list
+        // so the sidebar reflects it immediately, before the refetch lands.
+        queryClient.setQueryData<AskSessionSummary[]>(key, (old) => {
+          const now = new Date().toISOString();
+          const summary: AskSessionSummary = {
+            id: args.id,
+            userId,
+            title: args.title,
+            isPublic: false,
+            model: args.state.model,
+            createdAt: now,
+            updatedAt: now,
+          };
+          return old ? [summary, ...old] : [summary];
+        });
         void invalidate();
       },
     });
@@ -158,8 +173,33 @@ export function createUseSessions(deps: {
           .eq("id", args.id);
         if (error) throw new Error(error.message);
       },
-      onSuccess: () => {
-        void invalidate();
+      onSuccess: (_data, args) => {
+        // Only invalidate when something the sidebar actually displays
+        // changed. State-only saves (the 100ms autosave path) bump
+        // `updated_at` but nothing visible — and invalidating from there
+        // would churn the save effect via refetch-triggered renders,
+        // which is the whole autosave-loop bug we're preventing.
+        if ("title" in args.patch || "isPublic" in args.patch) {
+          // Patch the cached summary immediately for instant sidebar feedback.
+          queryClient.setQueryData<AskSessionSummary[]>(key, (old) =>
+            old
+              ? old.map((s) =>
+                  s.id === args.id
+                    ? {
+                        ...s,
+                        ...("title" in args.patch
+                          ? { title: args.patch.title ?? null }
+                          : {}),
+                        ...("isPublic" in args.patch
+                          ? { isPublic: args.patch.isPublic ?? s.isPublic }
+                          : {}),
+                      }
+                    : s
+                )
+              : old
+          );
+          void invalidate();
+        }
       },
     });
 
@@ -171,7 +211,12 @@ export function createUseSessions(deps: {
           .eq("id", id);
         if (error) throw new Error(error.message);
       },
-      onSuccess: () => {
+      onSuccess: (_data, id) => {
+        // Optimistic remove so the deleted row disappears from the
+        // sidebar without waiting for the refetch.
+        queryClient.setQueryData<AskSessionSummary[]>(key, (old) =>
+          old ? old.filter((s) => s.id !== id) : old
+        );
         void invalidate();
       },
     });

--- a/client/src/hooks/useSessions.ts
+++ b/client/src/hooks/useSessions.ts
@@ -1,6 +1,5 @@
 import { useSupabaseContext } from "@fluffylabs/shared-ui/supabase/context";
 import {
-  type QueryClient,
   useMutation,
   useQuery,
   useQueryClient,
@@ -92,6 +91,9 @@ export function createUseSessions(deps: {
   const { supabase, userId } = deps;
   return function useSessions(): UseSessionsApi {
     const queryClient = useQueryClient();
+    // `supabase` and `userId` are captured from the factory closure; they are
+    // stable for the lifetime of this hook instance, so they are omitted from
+    // the dep arrays below (the linter cannot tell).
     const key = useMemo(() => sessionsKey(userId), []);
 
     const query = useQuery<AskSessionSummary[], Error>({
@@ -181,26 +183,17 @@ export function createUseSessions(deps: {
       return fetchSessionById(supabase, id);
     }, []);
 
-    const create = useCallback<UseSessionsApi["create"]>(
-      async (args) => {
-        await createMutation.mutateAsync(args);
-      },
-      [createMutation]
-    );
+    const create: UseSessionsApi["create"] = async (args) => {
+      await createMutation.mutateAsync(args);
+    };
 
-    const update = useCallback<UseSessionsApi["update"]>(
-      async (id, patch) => {
-        await updateMutation.mutateAsync({ id, patch });
-      },
-      [updateMutation]
-    );
+    const update: UseSessionsApi["update"] = async (id, patch) => {
+      await updateMutation.mutateAsync({ id, patch });
+    };
 
-    const remove = useCallback(
-      async (id: string) => {
-        await removeMutation.mutateAsync(id);
-      },
-      [removeMutation]
-    );
+    const remove: UseSessionsApi["remove"] = async (id) => {
+      await removeMutation.mutateAsync(id);
+    };
 
     const mutationError =
       createMutation.error?.message ??
@@ -229,13 +222,3 @@ export function useSessions(): UseSessionsApi {
   return createUseSessions({ supabase: ctx.client, userId: ctx.user.id })();
 }
 
-/**
- * Helper for forcibly refreshing the sessions cache outside the hook (e.g.
- * after a fork from the shared-view page). Rarely needed.
- */
-export function invalidateSessions(
-  queryClient: QueryClient,
-  userId: string
-): void {
-  void queryClient.invalidateQueries({ queryKey: sessionsKey(userId) });
-}

--- a/client/src/hooks/useSessions.ts
+++ b/client/src/hooks/useSessions.ts
@@ -1,5 +1,6 @@
 import { useSupabaseContext } from "@fluffylabs/shared-ui/supabase/context";
 import {
+  type QueryClient,
   useMutation,
   useQuery,
   useQueryClient,
@@ -220,5 +221,19 @@ export function useSessions(): UseSessionsApi {
     throw new Error("useSessions requires an authenticated user");
   }
   return createUseSessions({ supabase: ctx.client, userId: ctx.user.id })();
+}
+
+/**
+ * Imperative cache invalidation for paths that write to `ask_sessions`
+ * outside the hook — currently `askShared.tsx::forkAndGo`, which inserts
+ * directly via the Supabase client and then navigates. Call after the
+ * insert so the sidebar picks up the new row on the next render instead
+ * of waiting for the next natural refetch.
+ */
+export function invalidateSessions(
+  queryClient: QueryClient,
+  userId: string
+): void {
+  void queryClient.invalidateQueries({ queryKey: sessionsKey(userId) });
 }
 

--- a/client/src/hooks/useSessions.ts
+++ b/client/src/hooks/useSessions.ts
@@ -1,6 +1,12 @@
 import { useSupabaseContext } from "@fluffylabs/shared-ui/supabase/context";
+import {
+  type QueryClient,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useMemo } from "react";
 import type { AskConversationState } from "@/lib/askTypes";
 import {
   type AskSessionRecord,
@@ -43,85 +49,101 @@ function rowToSummary(row: AskSessionRow): AskSessionSummary {
   };
 }
 
+function sessionsKey(userId: string): readonly unknown[] {
+  return ["ask_sessions", userId] as const;
+}
+
+async function fetchSessions(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<AskSessionSummary[]> {
+  const { data, error } = await supabase
+    .from("ask_sessions")
+    .select("id,user_id,title,is_public,model,created_at,updated_at")
+    .eq("user_id", userId)
+    .order("updated_at", { ascending: false });
+  if (error) throw new Error(error.message);
+  return (data as AskSessionRow[]).map(rowToSummary);
+}
+
+async function fetchSessionById(
+  supabase: SupabaseClient,
+  id: string
+): Promise<AskSessionRecord | null> {
+  const { data, error } = await supabase
+    .from("ask_sessions")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  if (!data) return null;
+  return fromRow(data as AskSessionRow);
+}
+
+/**
+ * Factory kept so tests can inject a stub Supabase client + userId without
+ * going through the SupabaseContext. Consumers in app code use the default
+ * `useSessions` export below.
+ */
 export function createUseSessions(deps: {
   supabase: SupabaseClient;
   userId: string;
 }) {
   const { supabase, userId } = deps;
   return function useSessions(): UseSessionsApi {
-    const [sessions, setSessions] = useState<AskSessionSummary[] | undefined>(
-      undefined
+    const queryClient = useQueryClient();
+    const key = useMemo(() => sessionsKey(userId), []);
+
+    const query = useQuery<AskSessionSummary[], Error>({
+      queryKey: key,
+      queryFn: () => fetchSessions(supabase, userId),
+    });
+
+    const invalidate = useCallback(
+      () => queryClient.invalidateQueries({ queryKey: key }),
+      [queryClient, key]
     );
-    const [error, setError] = useState<string | null>(null);
 
-    // supabase and userId are captured from the factory closure; they are
-    // stable for the lifetime of this hook instance, so they are omitted from
-    // the dep arrays below (the linter cannot tell).
-    //
-    // Mutating callbacks (create/update/remove) throw on failure in addition to
-    // setting the hook's `error` state. This lets callers choose: await with
-    // try/catch for operation-level handling, or read `sessions.error` for
-    // surfaced UI state.
-    const list = useCallback(async () => {
-      const { data, error } = await supabase
-        .from("ask_sessions")
-        .select("id,user_id,title,is_public,model,created_at,updated_at")
-        .eq("user_id", userId)
-        .order("updated_at", { ascending: false });
-      if (error) {
-        setError(error.message);
-        throw new Error(error.message);
-      }
-      setSessions((data as AskSessionRow[]).map(rowToSummary));
-    }, []);
-
-    // Uses maybeSingle so that a missing row returns null rather than erroring,
-    // letting callers distinguish "not found" from real query failures.
-    const get = useCallback(async (id: string) => {
-      const { data, error } = await supabase
-        .from("ask_sessions")
-        .select("*")
-        .eq("id", id)
-        .maybeSingle();
-      if (error) {
-        setError(error.message);
-        throw new Error(error.message);
-      }
-      if (!data) return null;
-      return fromRow(data as AskSessionRow);
-    }, []);
-
-    const create = useCallback<UseSessionsApi["create"]>(
-      async ({ id, title, state }) => {
+    const createMutation = useMutation({
+      mutationFn: async (args: {
+        id: string;
+        title: string | null;
+        state: AskConversationState;
+      }) => {
         const row = toRow({
-          id,
+          id: args.id,
           userId,
-          title,
+          title: args.title,
           isPublic: false,
-          state,
+          state: args.state,
         });
         const { error } = await supabase.from("ask_sessions").insert(row);
-        if (error) {
-          setError(error.message);
-          throw new Error(error.message);
-        }
-        await list();
+        if (error) throw new Error(error.message);
       },
-      [list]
-    );
+      onSuccess: () => {
+        void invalidate();
+      },
+    });
 
-    const update = useCallback<UseSessionsApi["update"]>(
-      async (id, patch) => {
+    const updateMutation = useMutation({
+      mutationFn: async (args: {
+        id: string;
+        patch: Partial<{
+          title: string | null;
+          isPublic: boolean;
+          state: AskConversationState;
+        }>;
+      }) => {
         const dbPatch: Record<string, unknown> = {};
-        if ("title" in patch) dbPatch.title = patch.title ?? null;
-        if ("isPublic" in patch) dbPatch.is_public = patch.isPublic;
-        if (patch.state) {
+        if ("title" in args.patch) dbPatch.title = args.patch.title ?? null;
+        if ("isPublic" in args.patch) dbPatch.is_public = args.patch.isPublic;
+        if (args.patch.state) {
           const row = toRow({
-            id,
+            id: args.id,
             userId,
             title: null,
             isPublic: false,
-            state: patch.state,
+            state: args.patch.state,
           });
           dbPatch.messages = row.messages;
           dbPatch.cards = row.cards;
@@ -130,38 +152,72 @@ export function createUseSessions(deps: {
         const { error } = await supabase
           .from("ask_sessions")
           .update(dbPatch)
-          .eq("id", id);
-        if (error) {
-          setError(error.message);
-          throw new Error(error.message);
-        }
-        await list();
+          .eq("id", args.id);
+        if (error) throw new Error(error.message);
       },
-      [list]
-    );
+      onSuccess: () => {
+        void invalidate();
+      },
+    });
 
-    const remove = useCallback(
-      async (id: string) => {
+    const removeMutation = useMutation({
+      mutationFn: async (id: string) => {
         const { error } = await supabase
           .from("ask_sessions")
           .delete()
           .eq("id", id);
-        if (error) {
-          setError(error.message);
-          throw new Error(error.message);
-        }
-        await list();
+        if (error) throw new Error(error.message);
       },
-      [list]
+      onSuccess: () => {
+        void invalidate();
+      },
+    });
+
+    const list = useCallback(async () => {
+      await queryClient.refetchQueries({ queryKey: key });
+    }, [queryClient, key]);
+
+    const get = useCallback(async (id: string) => {
+      return fetchSessionById(supabase, id);
+    }, []);
+
+    const create = useCallback<UseSessionsApi["create"]>(
+      async (args) => {
+        await createMutation.mutateAsync(args);
+      },
+      [createMutation]
     );
 
-    useEffect(() => {
-      // Errors are surfaced via `error` state; swallow the rejection here to
-      // avoid unhandled-promise warnings.
-      list().catch(() => {});
-    }, [list]);
+    const update = useCallback<UseSessionsApi["update"]>(
+      async (id, patch) => {
+        await updateMutation.mutateAsync({ id, patch });
+      },
+      [updateMutation]
+    );
 
-    return { sessions, error, list, get, create, update, remove };
+    const remove = useCallback(
+      async (id: string) => {
+        await removeMutation.mutateAsync(id);
+      },
+      [removeMutation]
+    );
+
+    const mutationError =
+      createMutation.error?.message ??
+      updateMutation.error?.message ??
+      removeMutation.error?.message ??
+      null;
+    const error = query.error?.message ?? mutationError ?? null;
+
+    return {
+      sessions: query.data,
+      error,
+      list,
+      get,
+      create,
+      update,
+      remove,
+    };
   };
 }
 
@@ -171,4 +227,15 @@ export function useSessions(): UseSessionsApi {
     throw new Error("useSessions requires an authenticated user");
   }
   return createUseSessions({ supabase: ctx.client, userId: ctx.user.id })();
+}
+
+/**
+ * Helper for forcibly refreshing the sessions cache outside the hook (e.g.
+ * after a fork from the shared-view page). Rarely needed.
+ */
+export function invalidateSessions(
+  queryClient: QueryClient,
+  userId: string
+): void {
+  void queryClient.invalidateQueries({ queryKey: sessionsKey(userId) });
 }

--- a/client/src/hooks/useSessions.ts
+++ b/client/src/hooks/useSessions.ts
@@ -1,11 +1,11 @@
 import { useSupabaseContext } from "@fluffylabs/shared-ui/supabase/context";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import {
   type QueryClient,
   useMutation,
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import type { SupabaseClient } from "@supabase/supabase-js";
 import { useCallback, useMemo } from "react";
 import type { AskConversationState } from "@/lib/askTypes";
 import {
@@ -236,4 +236,3 @@ export function invalidateSessions(
 ): void {
   void queryClient.invalidateQueries({ queryKey: sessionsKey(userId) });
 }
-

--- a/client/src/pages/ask.tsx
+++ b/client/src/pages/ask.tsx
@@ -332,7 +332,7 @@ export function AskPage() {
   useDocumentTitle(askTitle);
 
   return (
-    <div className="flex flex-col h-full bg-background text-foreground">
+    <div className="flex flex-col h-full bg-background text-foreground font-light">
       {saveError && (
         <div
           role="alert"
@@ -413,9 +413,7 @@ export function AskPage() {
 
         <aside className="hidden lg:flex flex-col border-l-1 border-l-white dark:border-l-[#353535] bg-card/20 text-foreground overflow-hidden">
           <div className="h-12 shrink-0 border-b-1 border-b-[#D4D4D4] dark:border-b-[#181818] px-5 flex items-center gap-2">
-            <span className="text-sm font-semibold text-foreground">
-              Sources
-            </span>
+            <span className="text-sm text-foreground">Sources</span>
             <span className="text-xs text-muted-foreground tabular-nums">
               {lastAssistant?.citations?.length ?? 0}
             </span>
@@ -456,15 +454,13 @@ function SessionSectionHeader({
 }) {
   return (
     <div className="h-12 shrink-0 border-b-1 border-b-[#D4D4D4] dark:border-b-[#181818] px-6 flex items-center gap-3">
-      <div className="flex-1 min-w-0 truncate text-sm font-medium text-foreground">
+      <div className="flex-1 min-w-0 truncate text-sm text-foreground">
         {sessionId ? (
           (activeSession?.title ?? (
             <Skeleton className="h-4 w-48 inline-block align-middle" />
           ))
         ) : (
-          <span className="text-muted-foreground font-normal">
-            New conversation
-          </span>
+          <span className="text-muted-foreground">New conversation</span>
         )}
       </div>
       {sessionId && activeSession && !isHydrating && (
@@ -516,9 +512,7 @@ function EmptyState({ showApiKeyCta, onOpenSettings }: EmptyStateProps) {
       <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-brand-light text-brand-dark dark:bg-brand-dark dark:text-brand mb-5">
         <Sparkles className="h-5 w-5" />
       </div>
-      <h2 className="text-2xl font-semibold text-foreground mb-3">
-        Ask anything about JAM
-      </h2>
+      <h2 className="text-2xl text-foreground mb-3">Ask anything about JAM</h2>
       <p className="text-sm text-muted-foreground leading-relaxed max-w-[28rem] mx-auto">
         An agent will search the Graypaper, Discord and Matrix discussions, and
         indexed pages, then answer with cited sources.

--- a/client/src/pages/ask.tsx
+++ b/client/src/pages/ask.tsx
@@ -280,12 +280,6 @@ export function AskPage() {
   const streaming = lastAssistant?.isStreaming === true;
   const isEmpty = state.messages.length === 0;
 
-  const handleNewChat = () => {
-    streamHandleRef.current?.abort();
-    streamHandleRef.current = null;
-    navigate("/ask");
-  };
-
   const activeSession = sessionId
     ? sessions.sessions?.find((s) => s.id === sessionId)
     : undefined;
@@ -337,9 +331,9 @@ export function AskPage() {
               />
             ) : (
               <>
-                <div className="sticky top-0 z-10 backdrop-blur bg-background/80 border-b border-border/60">
-                  <div className="max-w-[52rem] mx-auto px-6 py-2 flex items-center justify-end gap-1">
-                    {activeSession && sessionId && (
+                {activeSession && sessionId && (
+                  <div className="sticky top-0 z-10 backdrop-blur bg-background/80 border-b border-border/60">
+                    <div className="max-w-[52rem] mx-auto px-6 py-2 flex items-center justify-end gap-1">
                       <SharePopover
                         sessionId={sessionId}
                         isPublic={activeSession.isPublic}
@@ -347,12 +341,9 @@ export function AskPage() {
                           sessions.update(sessionId, { isPublic: next })
                         }
                       />
-                    )}
-                    <Button variant="ghost" size="sm" onClick={handleNewChat}>
-                      New chat
-                    </Button>
+                    </div>
                   </div>
-                </div>
+                )}
                 <div className="max-w-[52rem] mx-auto px-6 py-8 flex flex-col gap-6">
                   {state.messages.map((m) => (
                     <Message key={m.id} message={m} />

--- a/client/src/pages/ask.tsx
+++ b/client/src/pages/ask.tsx
@@ -364,7 +364,7 @@ export function AskPage() {
         </div>
       )}
       <div className="flex-1 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_22rem] overflow-hidden">
-        <section className="flex flex-col overflow-hidden border-r-1 border-r-[#D4D4D4] dark:border-r-1 dark:border-r-[#181818]">
+        <section className="flex flex-col overflow-hidden border-l-1 border-l-white dark:border-l-[#353535] border-r-1 border-r-[#D4D4D4] dark:border-r-[#181818]">
           <SessionSectionHeader
             sessionId={sessionId}
             activeSession={activeSession}
@@ -373,7 +373,10 @@ export function AskPage() {
               if (sessionId) sessions.update(sessionId, { isPublic: next });
             }}
           />
-          <div ref={scrollRef} className="flex-1 overflow-y-auto">
+          <div
+            ref={scrollRef}
+            className="flex-1 overflow-y-auto border-t-1 border-t-white dark:border-t-[#353535]"
+          >
             {isHydrating ? (
               <SessionLoadingSkeleton />
             ) : isEmpty ? (
@@ -408,8 +411,8 @@ export function AskPage() {
           </div>
         </section>
 
-        <aside className="hidden lg:flex flex-col border-l-1 border-l-white dark:border-l-1 dark:border-l-[#353535] bg-card/20 text-foreground overflow-hidden">
-          <div className="h-12 shrink-0 border-b border-border/60 px-5 flex items-center gap-2">
+        <aside className="hidden lg:flex flex-col border-l-1 border-l-white dark:border-l-[#353535] bg-card/20 text-foreground overflow-hidden">
+          <div className="h-12 shrink-0 border-b-1 border-b-[#D4D4D4] dark:border-b-[#181818] px-5 flex items-center gap-2">
             <span className="text-sm font-semibold text-foreground">
               Sources
             </span>
@@ -417,7 +420,7 @@ export function AskPage() {
               {lastAssistant?.citations?.length ?? 0}
             </span>
           </div>
-          <div className="flex-1 overflow-y-auto px-5 py-4">
+          <div className="flex-1 overflow-y-auto px-5 py-4 border-t-1 border-t-white dark:border-t-[#353535]">
             {isHydrating ? (
               <div
                 className="flex flex-col gap-3"
@@ -452,7 +455,7 @@ function SessionSectionHeader({
   onToggleShare: (next: boolean) => void;
 }) {
   return (
-    <div className="h-12 shrink-0 border-b border-border/60 px-6 flex items-center gap-3">
+    <div className="h-12 shrink-0 border-b-1 border-b-[#D4D4D4] dark:border-b-[#181818] px-6 flex items-center gap-3">
       <div className="flex-1 min-w-0 truncate text-sm font-medium text-foreground">
         {sessionId ? (
           (activeSession?.title ?? (

--- a/client/src/pages/ask.tsx
+++ b/client/src/pages/ask.tsx
@@ -455,7 +455,7 @@ function SessionSectionHeader({
   onToggleShare: (next: boolean) => void;
 }) {
   return (
-    <div className="h-12 shrink-0 border-b-1 border-b-[#D4D4D4] dark:border-b-[#181818] px-6 flex items-center gap-3">
+    <div className="h-12 shrink-0 px-6 flex items-center gap-3">
       <div className="flex-1 min-w-0 truncate text-sm text-foreground">
         {sessionId ? (
           (activeSession?.title ?? (

--- a/client/src/pages/ask.tsx
+++ b/client/src/pages/ask.tsx
@@ -412,7 +412,9 @@ export function AskPage() {
         </section>
 
         <aside className="hidden lg:flex flex-col border-l-1 border-l-white dark:border-l-[#353535] bg-card/20 text-foreground overflow-hidden">
-          <div className="h-12 shrink-0 border-b-1 border-b-[#D4D4D4] dark:border-b-[#181818] px-5 flex items-center gap-2">
+          {/* Muted horizontal divider: only the light highlight line on the
+              content, no dark shadow on this header. */}
+          <div className="h-12 shrink-0 px-5 flex items-center gap-2">
             <span className="text-sm text-foreground">Sources</span>
             <span className="text-xs text-muted-foreground tabular-nums">
               {lastAssistant?.citations?.length ?? 0}

--- a/client/src/pages/ask.tsx
+++ b/client/src/pages/ask.tsx
@@ -8,6 +8,7 @@ import { ChatInput } from "@/components/chat/ChatInput";
 import { CitationsPanel } from "@/components/chat/CitationsPanel";
 import { Message } from "@/components/chat/Message";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useAskConversation } from "@/hooks/useAskConversation";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { type UseSessionsApi, useSessions } from "@/hooks/useSessions";
@@ -59,6 +60,10 @@ export function AskPage() {
     sessionsRef.current = sessions;
   }, [sessions]);
   const [saveError, setSaveError] = useState<string | null>(null);
+  // Set while fetching a session's full record from the DB on navigation.
+  // Controls the loading skeleton so the UI changes immediately instead of
+  // showing the previous session's messages during the network round-trip.
+  const [isHydrating, setIsHydrating] = useState(false);
 
   // Hydrate when sessionId changes. Abort any running stream first.
   // Intentionally NOT depending on `sessions` — see sessionsRef above.
@@ -92,11 +97,13 @@ export function AskPage() {
     if (hydratedRef.current === sessionId) return;
     streamHandleRef.current?.abort();
     streamHandleRef.current = null;
+    setIsHydrating(true);
     let cancelled = false;
     (async () => {
       const record = await sessionsRef.current.get(sessionId);
       if (cancelled) return;
       if (!record) {
+        setIsHydrating(false);
         navigate("/ask", { replace: true });
         return;
       }
@@ -105,6 +112,7 @@ export function AskPage() {
       // The hydrated state is by definition what's in the DB; mark it so
       // the save effect doesn't immediately re-save it on the next render.
       lastSavedStateRef.current = record.state;
+      setIsHydrating(false);
     })();
     return () => {
       cancelled = true;
@@ -358,26 +366,33 @@ export function AskPage() {
       <div className="flex-1 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_22rem] overflow-hidden">
         <section className="flex flex-col overflow-hidden border-r-1 border-r-[#D4D4D4] dark:border-r-1 dark:border-r-[#181818]">
           <div ref={scrollRef} className="flex-1 overflow-y-auto">
-            {isEmpty ? (
+            {isHydrating ? (
+              <>
+                <SessionStickyHeader
+                  sessionId={sessionId}
+                  activeSession={activeSession}
+                  onToggleShare={(next) => {
+                    if (sessionId)
+                      sessions.update(sessionId, { isPublic: next });
+                  }}
+                />
+                <SessionLoadingSkeleton />
+              </>
+            ) : isEmpty ? (
               <EmptyState
                 showApiKeyCta={isReady && !hasApiKey}
                 onOpenSettings={() => navigate("/settings")}
               />
             ) : (
               <>
-                {activeSession && sessionId && (
-                  <div className="sticky top-0 z-10 backdrop-blur bg-background/80 border-b border-border/60">
-                    <div className="max-w-[52rem] mx-auto px-6 py-2 flex items-center justify-end gap-1">
-                      <SharePopover
-                        sessionId={sessionId}
-                        isPublic={activeSession.isPublic}
-                        onToggle={(next) =>
-                          sessions.update(sessionId, { isPublic: next })
-                        }
-                      />
-                    </div>
-                  </div>
-                )}
+                <SessionStickyHeader
+                  sessionId={sessionId}
+                  activeSession={activeSession}
+                  onToggleShare={(next) => {
+                    if (sessionId)
+                      sessions.update(sessionId, { isPublic: next });
+                  }}
+                />
                 <div className="max-w-[52rem] mx-auto px-6 py-8 flex flex-col gap-6">
                   {state.messages.map((m) => (
                     <Message key={m.id} message={m} />
@@ -390,22 +405,95 @@ export function AskPage() {
           <div className="max-w-[52rem] w-full mx-auto px-6 pb-6">
             <ChatInput
               initialValue={autoSubmit ? "" : initialQuery}
-              disabled={streaming || !isReady}
+              disabled={streaming || !isReady || isHydrating}
               onSubmit={send}
               model={state.model}
               onModelChange={(m) => dispatch({ type: "setModel", model: m })}
               placeholder={
                 isEmpty
                   ? "What would you like to know about JAM?"
-                  : "Ask a follow-up…"
+                  : isHydrating
+                    ? "Loading conversation…"
+                    : "Ask a follow-up…"
               }
             />
           </div>
         </section>
 
         <aside className="hidden lg:block border-l-1 border-l-white dark:border-l-1 dark:border-l-[#353535] overflow-y-auto bg-card/20 px-5 py-6 text-foreground">
-          <CitationsPanel assistant={lastAssistant} cards={state.cards} />
+          {isHydrating ? (
+            <div
+              className="flex flex-col gap-3"
+              role="status"
+              aria-label="Loading sources"
+            >
+              <Skeleton className="h-20 w-full rounded-md" />
+              <Skeleton className="h-20 w-full rounded-md" />
+              <Skeleton className="h-20 w-full rounded-md" />
+            </div>
+          ) : (
+            <CitationsPanel assistant={lastAssistant} cards={state.cards} />
+          )}
         </aside>
+      </div>
+    </div>
+  );
+}
+
+function SessionStickyHeader({
+  sessionId,
+  activeSession,
+  onToggleShare,
+}: {
+  sessionId: string | undefined;
+  activeSession:
+    | { id: string; title: string | null; isPublic: boolean }
+    | undefined;
+  onToggleShare: (next: boolean) => void;
+}) {
+  if (!sessionId) return null;
+  return (
+    <div className="sticky top-0 z-10 backdrop-blur bg-background/80 border-b border-border/60">
+      <div className="max-w-[52rem] mx-auto px-6 py-2 flex items-center gap-3">
+        <div className="flex-1 min-w-0 truncate text-sm font-medium text-foreground">
+          {activeSession?.title ?? (
+            <Skeleton className="h-4 w-48 inline-block align-middle" />
+          )}
+        </div>
+        {activeSession && (
+          <SharePopover
+            sessionId={sessionId}
+            isPublic={activeSession.isPublic}
+            onToggle={onToggleShare}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SessionLoadingSkeleton() {
+  return (
+    <div
+      className="max-w-[52rem] mx-auto px-6 py-8 flex flex-col gap-6"
+      role="status"
+      aria-label="Loading conversation"
+    >
+      <div className="flex justify-end">
+        <Skeleton className="h-10 w-56 rounded-xl" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-11/12" />
+        <Skeleton className="h-4 w-3/4" />
+      </div>
+      <div className="flex justify-end">
+        <Skeleton className="h-10 w-40 rounded-xl" />
+      </div>
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-5/6" />
+        <Skeleton className="h-4 w-2/3" />
       </div>
     </div>
   );

--- a/client/src/pages/ask.tsx
+++ b/client/src/pages/ask.tsx
@@ -100,19 +100,27 @@ export function AskPage() {
     setIsHydrating(true);
     let cancelled = false;
     (async () => {
-      const record = await sessionsRef.current.get(sessionId);
-      if (cancelled) return;
-      if (!record) {
+      try {
+        const record = await sessionsRef.current.get(sessionId);
+        if (cancelled) return;
+        if (!record) {
+          setIsHydrating(false);
+          navigate("/ask", { replace: true });
+          return;
+        }
+        dispatch({ type: "hydrate", state: record.state });
+        hydratedRef.current = sessionId;
+        // The hydrated state is by definition what's in the DB; mark it so
+        // the save effect doesn't immediately re-save it on the next render.
+        lastSavedStateRef.current = record.state;
         setIsHydrating(false);
-        navigate("/ask", { replace: true });
-        return;
+      } catch (err) {
+        if (cancelled) return;
+        // Surface the failure so the user sees the save-error bar and can
+        // retry; clear the skeleton so the UI isn't stuck indefinitely.
+        setIsHydrating(false);
+        setSaveError((err as Error).message);
       }
-      dispatch({ type: "hydrate", state: record.state });
-      hydratedRef.current = sessionId;
-      // The hydrated state is by definition what's in the DB; mark it so
-      // the save effect doesn't immediately re-save it on the next render.
-      lastSavedStateRef.current = record.state;
-      setIsHydrating(false);
     })();
     return () => {
       cancelled = true;
@@ -370,7 +378,10 @@ export function AskPage() {
             activeSession={activeSession}
             isHydrating={isHydrating}
             onToggleShare={(next) => {
-              if (sessionId) sessions.update(sessionId, { isPublic: next });
+              if (!sessionId) return;
+              sessions
+                .update(sessionId, { isPublic: next })
+                .catch((err) => setSaveError((err as Error).message));
             }}
           />
           <div

--- a/client/src/pages/ask.tsx
+++ b/client/src/pages/ask.tsx
@@ -64,6 +64,8 @@ export function AskPage() {
     if (createdRef.current.has(sessionId)) {
       // We just created this row locally; avoid an immediate round-trip
       // that would overwrite our in-memory state with the freshly-written one.
+      // Consume the flag so that navigating away and back re-hydrates from DB.
+      createdRef.current.delete(sessionId);
       hydratedRef.current = sessionId;
       return;
     }

--- a/client/src/pages/ask.tsx
+++ b/client/src/pages/ask.tsx
@@ -294,7 +294,7 @@ export function AskPage() {
   useDocumentTitle(askTitle);
 
   return (
-    <div className="flex flex-col h-full bg-background">
+    <div className="flex flex-col h-full bg-background text-foreground">
       {saveError && (
         <div
           role="alert"
@@ -369,7 +369,7 @@ export function AskPage() {
           </div>
         </section>
 
-        <aside className="hidden lg:block border-l-1 border-l-white dark:border-l-1 dark:border-l-[#353535] overflow-y-auto bg-card/20 px-5 py-6">
+        <aside className="hidden lg:block border-l-1 border-l-white dark:border-l-1 dark:border-l-[#353535] overflow-y-auto bg-card/20 px-5 py-6 text-foreground">
           <CitationsPanel assistant={lastAssistant} cards={state.cards} />
         </aside>
       </div>

--- a/client/src/pages/ask.tsx
+++ b/client/src/pages/ask.tsx
@@ -10,10 +10,10 @@ import { Message } from "@/components/chat/Message";
 import { Button } from "@/components/ui/button";
 import { useAskConversation } from "@/hooks/useAskConversation";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
-import { useSessions } from "@/hooks/useSessions";
+import { type UseSessionsApi, useSessions } from "@/hooks/useSessions";
 import { askStream } from "@/lib/askClient";
 import { requestTitle } from "@/lib/askTitleClient";
-import type { AssistantMessage } from "@/lib/askTypes";
+import type { AskConversationState, AssistantMessage } from "@/lib/askTypes";
 import { deriveTitle } from "@/lib/sessionTypes";
 
 export function AskPage() {
@@ -42,38 +42,59 @@ export function AskPage() {
   const hasAutoSubmittedRef = useRef(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const hydratedRef = useRef<string | null>(null);
-  const createdRef = useRef<Set<string>>(new Set());
   const stateRef = useRef(state);
+  // `sessions` identity changes on every react-query state transition
+  // (mutation pending, refetch, invalidation…). The hydrate/save effects
+  // only need access at call time, so we route through a ref instead of
+  // listing `sessions` as a dep and re-running on every render.
+  const sessionsRef = useRef<UseSessionsApi>(sessions);
+  // What we last persisted to the DB for the active session. When the
+  // reducer state matches this reference, the save effect skips —
+  // preventing a save/invalidate/refetch/render loop.
+  const lastSavedStateRef = useRef<AskConversationState | null>(null);
   useEffect(() => {
     stateRef.current = state;
   }, [state]);
+  useEffect(() => {
+    sessionsRef.current = sessions;
+  }, [sessions]);
   const [saveError, setSaveError] = useState<string | null>(null);
 
   // Hydrate when sessionId changes. Abort any running stream first.
+  // Intentionally NOT depending on `sessions` — see sessionsRef above.
   useEffect(() => {
     if (!sessionId) {
       if (hydratedRef.current !== null) {
+        const prevSessionId = hydratedRef.current;
         streamHandleRef.current?.abort();
         streamHandleRef.current = null;
+        // Best-effort flush: the user may be navigating away mid-stream
+        // (e.g., clicking "New chat" during the answer). `abort()` kills
+        // the stream without firing `finishStreaming`, so the normal save
+        // effect won't run. Persist a snapshot so the session survives.
+        const snapshot = stateRef.current;
+        if (
+          snapshot.messages.length > 0 &&
+          lastSavedStateRef.current !== snapshot
+        ) {
+          void sessionsRef.current
+            .update(prevSessionId, { state: snapshot })
+            .catch(() => {
+              /* best-effort; user is leaving this session anyway */
+            });
+        }
         dispatch({ type: "reset" });
         hydratedRef.current = null;
+        lastSavedStateRef.current = null;
       }
       return;
     }
     if (hydratedRef.current === sessionId) return;
-    if (createdRef.current.has(sessionId)) {
-      // We just created this row locally; avoid an immediate round-trip
-      // that would overwrite our in-memory state with the freshly-written one.
-      // Consume the flag so that navigating away and back re-hydrates from DB.
-      createdRef.current.delete(sessionId);
-      hydratedRef.current = sessionId;
-      return;
-    }
     streamHandleRef.current?.abort();
     streamHandleRef.current = null;
     let cancelled = false;
     (async () => {
-      const record = await sessions.get(sessionId);
+      const record = await sessionsRef.current.get(sessionId);
       if (cancelled) return;
       if (!record) {
         navigate("/ask", { replace: true });
@@ -81,28 +102,36 @@ export function AskPage() {
       }
       dispatch({ type: "hydrate", state: record.state });
       hydratedRef.current = sessionId;
+      // The hydrated state is by definition what's in the DB; mark it so
+      // the save effect doesn't immediately re-save it on the next render.
+      lastSavedStateRef.current = record.state;
     })();
     return () => {
       cancelled = true;
     };
-  }, [sessionId, sessions, dispatch, navigate]);
+  }, [sessionId, dispatch, navigate]);
 
-  // Persist after an assistant turn finishes streaming.
+  // Persist after an assistant turn finishes streaming. Skip when the
+  // reducer state already matches what we persisted — otherwise the save
+  // loops via invalidate→refetch→render→reschedule.
   useEffect(() => {
     if (!sessionId) return;
     if (hydratedRef.current !== sessionId) return;
     const last = state.messages[state.messages.length - 1];
     if (!last || last.role !== "assistant" || last.isStreaming) return;
+    if (lastSavedStateRef.current === state) return;
     const timer = setTimeout(async () => {
+      const stateToSave = stateRef.current;
       try {
-        await sessions.update(sessionId, { state: stateRef.current });
+        await sessionsRef.current.update(sessionId, { state: stateToSave });
+        lastSavedStateRef.current = stateToSave;
         setSaveError(null);
       } catch (err) {
         setSaveError((err as Error).message);
       }
     }, 100);
     return () => clearTimeout(timer);
-  }, [sessionId, sessions, state]);
+  }, [sessionId, state]);
 
   const send = useCallback(
     async (text: string, options?: { startFresh?: boolean }) => {
@@ -119,10 +148,14 @@ export function AskPage() {
         return;
       }
 
+      // Snapshot the reducer state before dispatching; we need it for the
+      // provisional title and for building the outgoing message list.
+      const currentState = stateRef.current;
+
       if (options?.startFresh) dispatch({ type: "reset" });
       dispatch({ type: "sendUserMessage", text });
 
-      const priorMessages = options?.startFresh ? [] : state.messages;
+      const priorMessages = options?.startFresh ? [] : currentState.messages;
       const nextMessages = [
         ...priorMessages,
         { id: "pending", role: "user" as const, content: text },
@@ -133,38 +166,44 @@ export function AskPage() {
       let activeId = sessionId;
       if (!activeId) {
         activeId = uuidv4();
-        createdRef.current.add(activeId);
         const provisional = deriveTitle({
-          ...state,
+          ...currentState,
           messages: [{ id: "pending", role: "user", content: text }],
         });
         try {
-          await sessions.create({
+          await sessionsRef.current.create({
             id: activeId,
             title: provisional,
             state: {
-              ...state,
+              ...currentState,
               messages: [{ id: "pending", role: "user", content: text }],
             },
           });
+          // Mark the new row as already-hydrated BEFORE navigating so the
+          // hydrate effect short-circuits instead of round-tripping. Setting
+          // this before `await create` would be wrong — a re-render during
+          // the mutation's pending state would fire the nav-away flush path.
           hydratedRef.current = activeId;
           navigate(`/ask/${activeId}`, { replace: true });
           // Fire-and-forget title generation; patch the row when it resolves.
           const newId = activeId;
           requestTitle({ question: text, openrouterKey: apiKey }).then(
             (generated) => {
-              if (generated) sessions.update(newId, { title: generated });
+              if (generated) {
+                void sessionsRef.current.update(newId, { title: generated });
+              }
             }
           );
         } catch (err) {
           setSaveError((err as Error).message);
+          return;
         }
       }
 
       streamHandleRef.current = askStream(
         {
           messages: nextMessages,
-          model: state.model,
+          model: currentState.model,
           openrouterKey: apiKey,
         },
         (event) => {
@@ -208,16 +247,7 @@ export function AskPage() {
         }
       );
     },
-    [
-      isReady,
-      hasApiKey,
-      trimmedApiKey,
-      dispatch,
-      state,
-      sessionId,
-      sessions,
-      navigate,
-    ]
+    [isReady, hasApiKey, trimmedApiKey, dispatch, sessionId, navigate]
   );
 
   useEffect(() => {
@@ -307,7 +337,11 @@ export function AskPage() {
             onClick={async () => {
               if (!sessionId) return;
               try {
-                await sessions.update(sessionId, { state: stateRef.current });
+                const stateToSave = stateRef.current;
+                await sessionsRef.current.update(sessionId, {
+                  state: stateToSave,
+                });
+                lastSavedStateRef.current = stateToSave;
                 setSaveError(null);
               } catch (err) {
                 setSaveError((err as Error).message);

--- a/client/src/pages/ask.tsx
+++ b/client/src/pages/ask.tsx
@@ -365,40 +365,28 @@ export function AskPage() {
       )}
       <div className="flex-1 grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_22rem] overflow-hidden">
         <section className="flex flex-col overflow-hidden border-r-1 border-r-[#D4D4D4] dark:border-r-1 dark:border-r-[#181818]">
+          <SessionSectionHeader
+            sessionId={sessionId}
+            activeSession={activeSession}
+            isHydrating={isHydrating}
+            onToggleShare={(next) => {
+              if (sessionId) sessions.update(sessionId, { isPublic: next });
+            }}
+          />
           <div ref={scrollRef} className="flex-1 overflow-y-auto">
             {isHydrating ? (
-              <>
-                <SessionStickyHeader
-                  sessionId={sessionId}
-                  activeSession={activeSession}
-                  onToggleShare={(next) => {
-                    if (sessionId)
-                      sessions.update(sessionId, { isPublic: next });
-                  }}
-                />
-                <SessionLoadingSkeleton />
-              </>
+              <SessionLoadingSkeleton />
             ) : isEmpty ? (
               <EmptyState
                 showApiKeyCta={isReady && !hasApiKey}
                 onOpenSettings={() => navigate("/settings")}
               />
             ) : (
-              <>
-                <SessionStickyHeader
-                  sessionId={sessionId}
-                  activeSession={activeSession}
-                  onToggleShare={(next) => {
-                    if (sessionId)
-                      sessions.update(sessionId, { isPublic: next });
-                  }}
-                />
-                <div className="max-w-[52rem] mx-auto px-6 py-8 flex flex-col gap-6">
-                  {state.messages.map((m) => (
-                    <Message key={m.id} message={m} />
-                  ))}
-                </div>
-              </>
+              <div className="max-w-[52rem] mx-auto px-6 py-8 flex flex-col gap-6">
+                {state.messages.map((m) => (
+                  <Message key={m.id} message={m} />
+                ))}
+              </div>
             )}
           </div>
 
@@ -420,54 +408,69 @@ export function AskPage() {
           </div>
         </section>
 
-        <aside className="hidden lg:block border-l-1 border-l-white dark:border-l-1 dark:border-l-[#353535] overflow-y-auto bg-card/20 px-5 py-6 text-foreground">
-          {isHydrating ? (
-            <div
-              className="flex flex-col gap-3"
-              role="status"
-              aria-label="Loading sources"
-            >
-              <Skeleton className="h-20 w-full rounded-md" />
-              <Skeleton className="h-20 w-full rounded-md" />
-              <Skeleton className="h-20 w-full rounded-md" />
-            </div>
-          ) : (
-            <CitationsPanel assistant={lastAssistant} cards={state.cards} />
-          )}
+        <aside className="hidden lg:flex flex-col border-l-1 border-l-white dark:border-l-1 dark:border-l-[#353535] bg-card/20 text-foreground overflow-hidden">
+          <div className="h-12 shrink-0 border-b border-border/60 px-5 flex items-center gap-2">
+            <span className="text-sm font-semibold text-foreground">
+              Sources
+            </span>
+            <span className="text-xs text-muted-foreground tabular-nums">
+              {lastAssistant?.citations?.length ?? 0}
+            </span>
+          </div>
+          <div className="flex-1 overflow-y-auto px-5 py-4">
+            {isHydrating ? (
+              <div
+                className="flex flex-col gap-3"
+                role="status"
+                aria-label="Loading sources"
+              >
+                <Skeleton className="h-20 w-full rounded-md" />
+                <Skeleton className="h-20 w-full rounded-md" />
+                <Skeleton className="h-20 w-full rounded-md" />
+              </div>
+            ) : (
+              <CitationsPanel assistant={lastAssistant} cards={state.cards} />
+            )}
+          </div>
         </aside>
       </div>
     </div>
   );
 }
 
-function SessionStickyHeader({
+function SessionSectionHeader({
   sessionId,
   activeSession,
+  isHydrating,
   onToggleShare,
 }: {
   sessionId: string | undefined;
   activeSession:
     | { id: string; title: string | null; isPublic: boolean }
     | undefined;
+  isHydrating: boolean;
   onToggleShare: (next: boolean) => void;
 }) {
-  if (!sessionId) return null;
   return (
-    <div className="sticky top-0 z-10 backdrop-blur bg-background/80 border-b border-border/60">
-      <div className="max-w-[52rem] mx-auto px-6 py-2 flex items-center gap-3">
-        <div className="flex-1 min-w-0 truncate text-sm font-medium text-foreground">
-          {activeSession?.title ?? (
+    <div className="h-12 shrink-0 border-b border-border/60 px-6 flex items-center gap-3">
+      <div className="flex-1 min-w-0 truncate text-sm font-medium text-foreground">
+        {sessionId ? (
+          (activeSession?.title ?? (
             <Skeleton className="h-4 w-48 inline-block align-middle" />
-          )}
-        </div>
-        {activeSession && (
-          <SharePopover
-            sessionId={sessionId}
-            isPublic={activeSession.isPublic}
-            onToggle={onToggleShare}
-          />
+          ))
+        ) : (
+          <span className="text-muted-foreground font-normal">
+            New conversation
+          </span>
         )}
       </div>
+      {sessionId && activeSession && !isHydrating && (
+        <SharePopover
+          sessionId={sessionId}
+          isPublic={activeSession.isPublic}
+          onToggle={onToggleShare}
+        />
+      )}
     </div>
   );
 }

--- a/client/src/pages/askShared.tsx
+++ b/client/src/pages/askShared.tsx
@@ -1,6 +1,6 @@
 import { useSupabaseContext } from "@fluffylabs/shared-ui/supabase/context";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { useQueryClient, type QueryClient } from "@tanstack/react-query";
+import { type QueryClient, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { v4 as uuidv4 } from "uuid";
@@ -8,9 +8,9 @@ import { CitationsPanel } from "@/components/chat/CitationsPanel";
 import { Message } from "@/components/chat/Message";
 import { Button } from "@/components/ui/button";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
+import { invalidateSessions } from "@/hooks/useSessions";
 import type { AssistantMessage } from "@/lib/askTypes";
 import { consumeForkPending, markForkPending } from "@/lib/forkPending";
-import { invalidateSessions } from "@/hooks/useSessions";
 import {
   type AskSessionRecord,
   type AskSessionRow,
@@ -79,11 +79,15 @@ export function AskSharedPage() {
     if (!user || !sessionId || !(record && record !== "notfound")) return;
     const pending = consumeForkPending();
     if (pending === sessionId) {
-      forkAndGo({ client, userId: user.id, source: record, navigate, queryClient }).catch(
-        (err) => setForkError((err as Error).message)
-      );
+      forkAndGo({
+        client,
+        userId: user.id,
+        source: record,
+        navigate,
+        queryClient,
+      }).catch((err) => setForkError((err as Error).message));
     }
-  }, [user, sessionId, record, client, navigate]);
+  }, [user, sessionId, record, client, navigate, queryClient]);
 
   const sharedTitle = (() => {
     if (record === null || record === "notfound") return null;
@@ -114,7 +118,13 @@ export function AskSharedPage() {
       return;
     }
     try {
-      await forkAndGo({ client, userId: user.id, source: record, navigate, queryClient });
+      await forkAndGo({
+        client,
+        userId: user.id,
+        source: record,
+        navigate,
+        queryClient,
+      });
     } catch (err) {
       setForkError((err as Error).message);
     }

--- a/client/src/pages/askShared.tsx
+++ b/client/src/pages/askShared.tsx
@@ -1,5 +1,6 @@
 import { useSupabaseContext } from "@fluffylabs/shared-ui/supabase/context";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { v4 as uuidv4 } from "uuid";
@@ -9,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import type { AssistantMessage } from "@/lib/askTypes";
 import { consumeForkPending, markForkPending } from "@/lib/forkPending";
+import { invalidateSessions } from "@/hooks/useSessions";
 import {
   type AskSessionRecord,
   type AskSessionRow,
@@ -22,6 +24,7 @@ async function forkAndGo(args: {
   userId: string;
   source: AskSessionRecord;
   navigate: (path: string) => void;
+  queryClient: QueryClient;
 }) {
   const newId = uuidv4();
   const row = toRow({
@@ -33,12 +36,14 @@ async function forkAndGo(args: {
   });
   const { error } = await args.client.from("ask_sessions").insert(row);
   if (error) throw error;
+  invalidateSessions(args.queryClient, args.userId);
   args.navigate(`/ask/${newId}`);
 }
 
 export function AskSharedPage() {
   const { sessionId } = useParams<{ sessionId: string }>();
   const { client, user } = useSupabaseContext();
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [record, setRecord] = useState<AskSessionRecord | null | "notfound">(
     null
@@ -74,7 +79,7 @@ export function AskSharedPage() {
     if (!user || !sessionId || !(record && record !== "notfound")) return;
     const pending = consumeForkPending();
     if (pending === sessionId) {
-      forkAndGo({ client, userId: user.id, source: record, navigate }).catch(
+      forkAndGo({ client, userId: user.id, source: record, navigate, queryClient }).catch(
         (err) => setForkError((err as Error).message)
       );
     }
@@ -109,7 +114,7 @@ export function AskSharedPage() {
       return;
     }
     try {
-      await forkAndGo({ client, userId: user.id, source: record, navigate });
+      await forkAndGo({ client, userId: user.id, source: record, navigate, queryClient });
     } catch (err) {
       setForkError((err as Error).message);
     }

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -1,5 +1,8 @@
-import { Sparkles, Star, Target } from "lucide-react";
+import { useSupabaseContext } from "@fluffylabs/shared-ui/supabase/context";
+import { MessageSquareText, Sparkles, Star, Target } from "lucide-react";
+import { Link } from "react-router-dom";
 import { SearchForm } from "@/components/SearchForm";
+import { useSessions } from "@/hooks/useSessions";
 
 const Header = () => {
   return (
@@ -18,6 +21,33 @@ const Header = () => {
     </>
   );
 };
+/**
+ * Inner component that queries `useSessions` — safe to render only when we
+ * know the user is authenticated (the hook throws otherwise). Shows a subtle
+ * link to `/ask` when the user has at least one previous conversation.
+ */
+const PreviousConversationsLinkInner = () => {
+  const sessions = useSessions();
+  const count = sessions.sessions?.length ?? 0;
+  if (count === 0) return null;
+  return (
+    <Link
+      to="/ask"
+      className="mt-4 inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+    >
+      <MessageSquareText className="size-3.5" />
+      Continue a previous conversation
+      <span className="text-muted-foreground/70 tabular-nums">({count})</span>
+    </Link>
+  );
+};
+
+const PreviousConversationsLink = () => {
+  const { user } = useSupabaseContext();
+  if (!user) return null;
+  return <PreviousConversationsLinkInner />;
+};
+
 const Features = () => {
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-8 w-full mt-8">
@@ -65,6 +95,8 @@ export const IndexPage = () => {
           instantSearch={false}
           showSearchOptions={false}
         />
+
+        <PreviousConversationsLink />
 
         <Features />
       </div>

--- a/docs/superpowers/plans/2026-04-24-ask-ui-fixes.md
+++ b/docs/superpowers/plans/2026-04-24-ask-ui-fixes.md
@@ -1,0 +1,1353 @@
+# /ask UI fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix nine scoped /ask UI/UX defects: padding, broken session switching, missing text colors, dropdown parity, split session state, regenerate-title removal, "new chat" duplication, graypaper URL, share-from-dropdown flow.
+
+**Architecture:** Mostly targeted edits. One structural change: `useSessions` moves to `@tanstack/react-query` so the sidebar and the page share one cache. New dep: `sonner` for toasts.
+
+**Tech Stack:** React 19, TanStack Query 5, shadcn dropdowns, sonner, Vitest + React Testing Library, Node/Fastify backend.
+
+**Spec:** `docs/superpowers/specs/2026-04-24-ask-ui-fixes-design.md`
+
+---
+
+## File Map
+
+**Frontend**
+- Modify `client/package.json` — add `sonner` dep.
+- Modify `client/src/App.tsx` — widen `fullBleed`, mount `<Toaster />`.
+- Modify `client/src/pages/ask.tsx` — clear `createdRef` on first use, delete in-section "New chat" button.
+- Modify `client/src/components/ask/SessionRow.tsx` — remove "Regenerate title", align dropdown styling with ModelPicker, rewire Share to copy+toast+flip-public, add `text-foreground`.
+- Modify `client/src/components/ask/SessionsSidebar.tsx` — drop `onRegenerateTitle` prop, add `text-foreground` on aside.
+- Modify `client/src/components/ask/AskLayout.tsx` — drop `onRegenerateTitle` handler + unused import.
+- Modify `client/src/hooks/useSessions.ts` — rewrite on top of react-query; keep factory exported for tests.
+- Modify `client/src/hooks/__tests__/useSessions.test.ts` — wrap in `QueryClientProvider`.
+- Modify `client/src/components/ask/__tests__/SessionsSidebar.test.tsx` — remove `onRegenerateTitle` prop usage.
+
+**Backend**
+- Modify `backend/src/ask/tools.ts` — plumb query into `buildGraypaperUrl`, match search-page URL format.
+
+---
+
+## Task 1: Install sonner and mount Toaster
+
+**Files:**
+- Modify: `client/package.json`
+- Modify: `client/src/App.tsx`
+
+- [ ] **Step 1: Install sonner**
+
+Run in `client/`:
+
+```bash
+cd client && npm install sonner@^2.0.7
+```
+
+Expected: `sonner` added to `dependencies` in `client/package.json`.
+
+- [ ] **Step 2: Mount Toaster in App.tsx**
+
+Open `client/src/App.tsx`. Add the import near the other component imports (top of file, after line 9):
+
+```tsx
+import { Toaster } from "sonner";
+```
+
+Inside the JSX returned by `App()`, add `<Toaster />` just before `<ReactQueryDevtools initialIsOpen={false} />` (currently at line 162):
+
+```tsx
+      <Toaster position="bottom-right" richColors closeButton />
+      <ReactQueryDevtools initialIsOpen={false} />
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd client && npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/package.json client/package-lock.json client/src/App.tsx
+git commit -m "ask: install sonner and mount global Toaster"
+```
+
+---
+
+## Task 2: Widen `fullBleed` to cover all /ask subroutes
+
+**Files:**
+- Modify: `client/src/App.tsx:96`
+
+- [ ] **Step 1: Change the `fullBleed` expression**
+
+Open `client/src/App.tsx`. Replace:
+
+```tsx
+  // /ask manages its own scroll/padding so the section/aside border can
+  // span the full available height.
+  const fullBleed = pathname === "/ask";
+```
+
+with:
+
+```tsx
+  // /ask (and its nested session routes + shared view) manages its own
+  // scroll/padding so the section/aside border can span the full height
+  // and the shared page doesn't double-pad.
+  const fullBleed = pathname === "/ask" || pathname.startsWith("/ask/");
+```
+
+- [ ] **Step 2: Manual verification**
+
+Run `cd client && npm run dev`. In the browser:
+- `/ask` (empty state) — no outer `p-4` padding.
+- `/ask/<uuid>` (session view) — no outer `p-4` padding; content aligns with the empty state.
+- `/ask/s/<uuid>` (shared view) — no outer padding; the page's own `mx-auto max-w-5xl p-4` is intact.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/App.tsx
+git commit -m "ask: remove outer p-4 on session and shared routes"
+```
+
+---
+
+## Task 3: Fix session switching (clear `createdRef` on first use)
+
+**Files:**
+- Modify: `client/src/pages/ask.tsx:52-86`
+
+- [ ] **Step 1: Change the `createdRef` guard to consume-once**
+
+Open `client/src/pages/ask.tsx`. Replace this block (around line 63–69):
+
+```tsx
+    if (hydratedRef.current === sessionId) return;
+    if (createdRef.current.has(sessionId)) {
+      // We just created this row locally; avoid an immediate round-trip
+      // that would overwrite our in-memory state with the freshly-written one.
+      hydratedRef.current = sessionId;
+      return;
+    }
+```
+
+with:
+
+```tsx
+    if (hydratedRef.current === sessionId) return;
+    if (createdRef.current.has(sessionId)) {
+      // We just created this row locally; avoid an immediate round-trip
+      // that would overwrite our in-memory state with the freshly-written one.
+      // Consume the flag so that navigating away and back re-hydrates from DB.
+      createdRef.current.delete(sessionId);
+      hydratedRef.current = sessionId;
+      return;
+    }
+```
+
+- [ ] **Step 2: Manual verification**
+
+Run `cd client && npm run dev`. Reproduce and confirm the fix:
+1. Open `/ask`, send a question in session A → you land on `/ask/<A>`.
+2. Create a second chat via the sidebar "New chat", send a question → you land on `/ask/<B>` with B's messages showing.
+3. Click session A in the sidebar → A's messages should now appear (previously the page stayed on B).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/pages/ask.tsx
+git commit -m "ask: consume createdRef flag so session re-visits re-hydrate"
+```
+
+---
+
+## Task 4: Fix graypaper URL (match search-page format)
+
+**Files:**
+- Modify: `backend/src/ask/tools.ts:50-53, 162-171, 201-218`
+
+- [ ] **Step 1: Change `buildGraypaperUrl` to accept a query**
+
+Open `backend/src/ask/tools.ts`. Replace the function (lines 50–53):
+
+```ts
+function buildGraypaperUrl(title: string | undefined): string | undefined {
+  if (!title) return undefined;
+  return `https://graypaper.fluffylabs.dev/#/?section=${encodeURIComponent(title)}`;
+}
+```
+
+with:
+
+```ts
+function buildGraypaperUrl(
+  title: string | undefined,
+  query: string
+): string | undefined {
+  if (!title) return undefined;
+  // Match the search-results URL format byte-for-byte (no URL encoding).
+  // The Graypaper reader's hash router expects this exact shape.
+  return `https://graypaper.fluffylabs.dev/#/?search=${query}&section=${title}`;
+}
+```
+
+- [ ] **Step 2: Pass the search query through `executeSearchAll`**
+
+In the same file, inside `executeSearchAll` replace the graypaper push block (around line 162–171):
+
+```ts
+  for (const r of graypaper.results ?? []) {
+    out.push({
+      id: r.id,
+      sourceType: "graypaper",
+      preview: truncate(r.text ?? ""),
+      title: r.title,
+      url: buildGraypaperUrl(r.title),
+      score: r.score,
+    });
+  }
+```
+
+with:
+
+```ts
+  for (const r of graypaper.results ?? []) {
+    out.push({
+      id: r.id,
+      sourceType: "graypaper",
+      preview: truncate(r.text ?? ""),
+      title: r.title,
+      url: buildGraypaperUrl(r.title, args.query),
+      score: r.score,
+    });
+  }
+```
+
+- [ ] **Step 3: Update `resolveDocUrl` (no query available)**
+
+In the same file, replace the `resolveDocUrl` function (lines 201–218):
+
+```ts
+function resolveDocUrl(doc: SearchDoc): string | undefined {
+  switch (doc.type) {
+    case "page":
+      return doc.url;
+    case "discord":
+      return buildDiscordUrl(
+        doc.serverId,
+        doc.channelId,
+        doc.threadId,
+        doc.messageId
+      );
+    case "matrix":
+      return buildMatrixUrl(doc.roomId, doc.messageId);
+    case "graypaper_section":
+    case "graypaper_version":
+      return buildGraypaperUrl(doc.title);
+  }
+}
+```
+
+with:
+
+```ts
+function resolveDocUrl(doc: SearchDoc): string | undefined {
+  switch (doc.type) {
+    case "page":
+      return doc.url;
+    case "discord":
+      return buildDiscordUrl(
+        doc.serverId,
+        doc.channelId,
+        doc.threadId,
+        doc.messageId
+      );
+    case "matrix":
+      return buildMatrixUrl(doc.roomId, doc.messageId);
+    case "graypaper_section":
+    case "graypaper_version":
+      // No search query context here; fall back to empty query so the
+      // reader still routes to the section.
+      return buildGraypaperUrl(doc.title, "");
+  }
+}
+```
+
+- [ ] **Step 4: Typecheck backend**
+
+Run: `cd backend && npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 5: Manual verification**
+
+Start the dev stack (`cd backend && npm run dev`, then `cd client && npm run dev`). Ask a question that triggers a graypaper citation. Click the resulting "Open reader" link in the sidebar. It should open the Graypaper reader scrolled to the cited section — identical behavior to clicking a result from the search page.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/ask/tools.ts
+git commit -m "ask: match search-page graypaper URL format so reader links resolve"
+```
+
+---
+
+## Task 5: Remove "Regenerate title" from session dropdown
+
+**Files:**
+- Modify: `client/src/components/ask/SessionRow.tsx`
+- Modify: `client/src/components/ask/SessionsSidebar.tsx`
+- Modify: `client/src/components/ask/AskLayout.tsx`
+- Modify: `client/src/components/ask/__tests__/SessionsSidebar.test.tsx`
+
+- [ ] **Step 1: Drop the menu item + prop in `SessionRow.tsx`**
+
+Open `client/src/components/ask/SessionRow.tsx`. Replace the whole file with:
+
+```tsx
+import { MoreHorizontal } from "lucide-react";
+import { Link } from "react-router-dom";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { AskSessionSummary } from "@/lib/sessionTypes";
+import { cn } from "@/lib/utils";
+
+export function SessionRow({
+  session,
+  active,
+  onRename,
+  onDelete,
+  onShare,
+}: {
+  session: AskSessionSummary;
+  active: boolean;
+  onRename: (id: string) => void;
+  onDelete: (id: string) => void;
+  onShare: (id: string) => void;
+}) {
+  return (
+    <div
+      className={cn(
+        "group flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground hover:bg-accent",
+        active && "bg-accent"
+      )}
+    >
+      <Link
+        to={`/ask/${session.id}`}
+        className="flex-1 min-w-0 truncate text-foreground"
+        title={session.title ?? "Untitled"}
+      >
+        {session.title ?? "Untitled"}
+      </Link>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          className="opacity-0 group-hover:opacity-100 focus:opacity-100 text-muted-foreground hover:text-foreground"
+          aria-label="Session actions"
+        >
+          <MoreHorizontal className="size-4" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={() => onRename(session.id)}>
+            Rename
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => onShare(session.id)}>
+            Share…
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="text-destructive focus:text-destructive"
+            onClick={() => onDelete(session.id)}
+          >
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+```
+
+Notes on this step: the `onToggleShare` prop is being replaced by a single `onShare(id)` (the share logic — flip public, copy, toast — is implemented in Task 10 and lives in `AskLayout`). "Regenerate title" is gone. Styling cleanup (`text-foreground`, `text-muted-foreground` on trigger) is included here because these are all in the same file — leaving the styling for Task 7 would mean re-touching it.
+
+- [ ] **Step 2: Remove `onRegenerateTitle` from `SessionsSidebar.tsx` and rename `onToggleShare` → `onShare`**
+
+Open `client/src/components/ask/SessionsSidebar.tsx`. Replace the whole file with:
+
+```tsx
+import { Plus } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { SessionRow } from "@/components/ask/SessionRow";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { groupSessions } from "@/lib/groupSessions";
+import type { AskSessionSummary } from "@/lib/sessionTypes";
+
+export function SessionsSidebar({
+  sessions,
+  activeId,
+  now,
+  onRename,
+  onDelete,
+  onShare,
+}: {
+  sessions: AskSessionSummary[];
+  activeId: string | null;
+  now?: Date;
+  onRename: (id: string) => void;
+  onDelete: (id: string) => void;
+  onShare: (id: string) => void;
+}) {
+  const [filter, setFilter] = useState("");
+  const filtered = useMemo(() => {
+    if (!filter.trim()) return sessions;
+    const needle = filter.toLowerCase();
+    return sessions.filter((s) =>
+      (s.title ?? "Untitled").toLowerCase().includes(needle)
+    );
+  }, [sessions, filter]);
+  const groups = useMemo(() => groupSessions(filtered, now), [filtered, now]);
+
+  return (
+    <aside className="flex w-64 shrink-0 flex-col border-r border-border bg-card/50 text-foreground">
+      <div className="p-2">
+        <Button asChild size="sm" variant="outline" className="w-full">
+          <Link to="/ask">
+            <Plus className="size-4" /> New chat
+          </Link>
+        </Button>
+      </div>
+      <div className="px-2 pb-2">
+        <Input
+          placeholder="Filter…"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          aria-label="Filter sessions"
+        />
+      </div>
+      <div className="flex-1 overflow-y-auto px-2 pb-2">
+        {groups.map((group) => (
+          <div key={group.label} className="mb-3">
+            <div className="px-2 py-1 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              {group.label}
+            </div>
+            {group.sessions.map((s) => (
+              <SessionRow
+                key={s.id}
+                session={s}
+                active={s.id === activeId}
+                onRename={onRename}
+                onDelete={onDelete}
+                onShare={onShare}
+              />
+            ))}
+          </div>
+        ))}
+        {filtered.length === 0 && (
+          <div className="p-4 text-center text-sm text-muted-foreground">
+            {sessions.length === 0 ? "No sessions yet." : "No matches."}
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}
+```
+
+- [ ] **Step 3: Remove `onRegenerateTitle` wiring from `AskLayout.tsx` (placeholder onShare for now)**
+
+Open `client/src/components/ask/AskLayout.tsx`. Replace the whole file with:
+
+```tsx
+import { Outlet, useParams } from "react-router-dom";
+import { AuthGate } from "@/components/ask/AuthGate";
+import { SessionsSidebar } from "@/components/ask/SessionsSidebar";
+import { useSessions } from "@/hooks/useSessions";
+
+export function AskLayout() {
+  return (
+    <AuthGate>
+      <LayoutInner />
+    </AuthGate>
+  );
+}
+
+function LayoutInner() {
+  const { sessionId } = useParams<{ sessionId?: string }>();
+  const sessions = useSessions();
+
+  return (
+    <div className="flex h-full">
+      <SessionsSidebar
+        sessions={sessions.sessions ?? []}
+        activeId={sessionId ?? null}
+        onRename={(id) => {
+          const nextTitle = window.prompt("New title?");
+          if (nextTitle !== null && nextTitle.trim() !== "") {
+            sessions.update(id, { title: nextTitle.trim() });
+          }
+        }}
+        onDelete={(id) => {
+          if (
+            window.confirm("Delete this session? Any public link will 404.")
+          ) {
+            sessions.remove(id);
+          }
+        }}
+        onShare={() => {
+          // Implemented in Task 10 (flip public + copy + toast).
+        }}
+      />
+      <div className="flex-1 min-w-0">
+        <Outlet />
+      </div>
+    </div>
+  );
+}
+```
+
+Notes on this step: we intentionally leave `onShare` as a no-op here. Task 10 will replace this body.
+
+- [ ] **Step 4: Fix `SessionsSidebar.test.tsx`**
+
+Open `client/src/components/ask/__tests__/SessionsSidebar.test.tsx`. Replace:
+
+```tsx
+      <SessionsSidebar
+        sessions={sessions}
+        activeId={null}
+        now={new Date("2026-04-23T12:00:00Z")}
+        onRename={vi.fn()}
+        onDelete={vi.fn()}
+        onToggleShare={vi.fn()}
+        onRegenerateTitle={vi.fn()}
+      />
+```
+
+with:
+
+```tsx
+      <SessionsSidebar
+        sessions={sessions}
+        activeId={null}
+        now={new Date("2026-04-23T12:00:00Z")}
+        onRename={vi.fn()}
+        onDelete={vi.fn()}
+        onShare={vi.fn()}
+      />
+```
+
+- [ ] **Step 5: Run tests and typecheck**
+
+Run: `cd client && npm run typecheck && npm test`
+Expected: typecheck clean, all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add client/src/components/ask/SessionRow.tsx \
+        client/src/components/ask/SessionsSidebar.tsx \
+        client/src/components/ask/AskLayout.tsx \
+        client/src/components/ask/__tests__/SessionsSidebar.test.tsx
+git commit -m "ask: drop regenerate-title action; introduce onShare prop"
+```
+
+---
+
+## Task 6: Remove "New chat" button from ask.tsx main section
+
+**Files:**
+- Modify: `client/src/pages/ask.tsx:281-297, 349-351`
+
+- [ ] **Step 1: Delete the button and its handler**
+
+Open `client/src/pages/ask.tsx`. Delete `handleNewChat` (around lines 281–285):
+
+```tsx
+  const handleNewChat = () => {
+    streamHandleRef.current?.abort();
+    streamHandleRef.current = null;
+    navigate("/ask");
+  };
+```
+
+And replace the sticky-header content (around lines 338–353):
+
+```tsx
+                <div className="sticky top-0 z-10 backdrop-blur bg-background/80 border-b border-border/60">
+                  <div className="max-w-[52rem] mx-auto px-6 py-2 flex items-center justify-end gap-1">
+                    {activeSession && sessionId && (
+                      <SharePopover
+                        sessionId={sessionId}
+                        isPublic={activeSession.isPublic}
+                        onToggle={(next) =>
+                          sessions.update(sessionId, { isPublic: next })
+                        }
+                      />
+                    )}
+                    <Button variant="ghost" size="sm" onClick={handleNewChat}>
+                      New chat
+                    </Button>
+                  </div>
+                </div>
+```
+
+with:
+
+```tsx
+                {activeSession && sessionId && (
+                  <div className="sticky top-0 z-10 backdrop-blur bg-background/80 border-b border-border/60">
+                    <div className="max-w-[52rem] mx-auto px-6 py-2 flex items-center justify-end gap-1">
+                      <SharePopover
+                        sessionId={sessionId}
+                        isPublic={activeSession.isPublic}
+                        onToggle={(next) =>
+                          sessions.update(sessionId, { isPublic: next })
+                        }
+                      />
+                    </div>
+                  </div>
+                )}
+```
+
+Notes on this step: the whole sticky header is now conditional — without `SharePopover` and without "New chat", there's nothing to show otherwise.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd client && npm run typecheck`
+Expected: no errors (no stray references to `handleNewChat`).
+
+- [ ] **Step 3: Manual verification**
+
+Start dev; open an existing session. The sticky header should only show the Share button. Start a fresh chat (empty state, `/ask`) — no header at all, only the centered empty state.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/pages/ask.tsx
+git commit -m "ask: drop redundant New chat button from session header"
+```
+
+---
+
+## Task 7: Add `text-foreground` where missing
+
+**Files:**
+- Modify: `client/src/pages/ask.tsx` (sticky header wrapper, if inherited color is off)
+
+Most of the drift lives in `SessionRow` / `SessionsSidebar`, already addressed in Task 5. This task sweeps the remaining /ask surfaces.
+
+- [ ] **Step 1: Audit + tweak `ask.tsx` surfaces**
+
+Open `client/src/pages/ask.tsx`. Verify:
+
+- The outer wrapper already has `bg-background`. `text-foreground` should be added so descendants without explicit colors render correctly. Change line 301:
+
+```tsx
+    <div className="flex flex-col h-full bg-background">
+```
+
+to:
+
+```tsx
+    <div className="flex flex-col h-full bg-background text-foreground">
+```
+
+- The `<aside>` on line 379:
+
+```tsx
+        <aside className="hidden lg:block border-l-1 border-l-white dark:border-l-1 dark:border-l-[#353535] overflow-y-auto bg-card/20 px-5 py-6">
+```
+
+Change to:
+
+```tsx
+        <aside className="hidden lg:block border-l-1 border-l-white dark:border-l-1 dark:border-l-[#353535] overflow-y-auto bg-card/20 px-5 py-6 text-foreground">
+```
+
+- [ ] **Step 2: Manual verification in dark mode**
+
+Run `cd client && npm run dev`. Toggle dark mode via the apps sidebar. Check that session-row titles, the citations panel text, and any descendant text renders with the foreground color (no muddy/low-contrast grays leaking through).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/pages/ask.tsx
+git commit -m "ask: add explicit text-foreground on /ask shells"
+```
+
+---
+
+## Task 8: Align session dropdown visuals with ModelPicker
+
+**Files:**
+- Modify: `client/src/components/ask/SessionRow.tsx`
+
+`DropdownMenuLabel` + `DropdownMenuSeparator` (already present in `ui/dropdown-menu.tsx`) give the ModelPicker its distinctive hierarchy. Session row should use the same primitives for visual parity.
+
+- [ ] **Step 1: Add a label and separator to `SessionRow`'s dropdown**
+
+Open `client/src/components/ask/SessionRow.tsx`. Extend the existing imports:
+
+```tsx
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+```
+
+Replace the `DropdownMenuContent` body:
+
+```tsx
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={() => onRename(session.id)}>
+            Rename
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => onShare(session.id)}>
+            Share…
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="text-destructive focus:text-destructive"
+            onClick={() => onDelete(session.id)}
+          >
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+```
+
+with:
+
+```tsx
+        <DropdownMenuContent align="end" className="min-w-[12rem]">
+          <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+            Session
+          </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onClick={() => onRename(session.id)}
+          >
+            Rename
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="cursor-pointer"
+            onClick={() => onShare(session.id)}
+          >
+            Share…
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            className="cursor-pointer text-destructive focus:text-destructive"
+            onClick={() => onDelete(session.id)}
+          >
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+```
+
+Rationale: mirrors `ModelPicker` — a muted header label, a separator, then items. Same base `DropdownMenuItem` styling, `min-w-[12rem]` sized for the short session menu (ModelPicker uses `min-w-[18rem]` because model labels are longer).
+
+- [ ] **Step 2: Manual verification**
+
+Run `cd client && npm run dev`. Open `/ask`, hover a session row, click the `⋯` button. The menu should have a "Session" label row, a separator, then items matching the ModelPicker visual weight.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/src/components/ask/SessionRow.tsx
+git commit -m "ask: align session dropdown hierarchy with ModelPicker"
+```
+
+---
+
+## Task 9: Refactor `useSessions` to a react-query-backed shared cache
+
+**Files:**
+- Modify: `client/src/hooks/useSessions.ts`
+- Modify: `client/src/hooks/__tests__/useSessions.test.ts`
+
+Root cause of "sessions randomly appear/disappear": `AskLayout` and `AskPage` each instantiate `useSessions()` and hold independent `useState` arrays. Moving to react-query puts the list in one shared cache keyed by `["ask_sessions", userId]`; mutations invalidate it and both consumers re-read automatically.
+
+- [ ] **Step 1: Rewrite `useSessions.ts`**
+
+Open `client/src/hooks/useSessions.ts`. Replace the whole file with:
+
+```ts
+import { useSupabaseContext } from "@fluffylabs/shared-ui/supabase/context";
+import {
+  type QueryClient,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { useCallback, useMemo } from "react";
+import type { AskConversationState } from "@/lib/askTypes";
+import {
+  type AskSessionRecord,
+  type AskSessionRow,
+  type AskSessionSummary,
+  fromRow,
+  toRow,
+} from "@/lib/sessionTypes";
+
+export interface UseSessionsApi {
+  sessions: AskSessionSummary[] | undefined;
+  error: string | null;
+  list: () => Promise<void>;
+  get: (id: string) => Promise<AskSessionRecord | null>;
+  create: (args: {
+    id: string;
+    title: string | null;
+    state: AskConversationState;
+  }) => Promise<void>;
+  update: (
+    id: string,
+    patch: Partial<{
+      title: string | null;
+      isPublic: boolean;
+      state: AskConversationState;
+    }>
+  ) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+}
+
+function rowToSummary(row: AskSessionRow): AskSessionSummary {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    title: row.title,
+    isPublic: row.is_public,
+    model: row.model,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function sessionsKey(userId: string): readonly unknown[] {
+  return ["ask_sessions", userId] as const;
+}
+
+async function fetchSessions(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<AskSessionSummary[]> {
+  const { data, error } = await supabase
+    .from("ask_sessions")
+    .select("id,user_id,title,is_public,model,created_at,updated_at")
+    .eq("user_id", userId)
+    .order("updated_at", { ascending: false });
+  if (error) throw new Error(error.message);
+  return (data as AskSessionRow[]).map(rowToSummary);
+}
+
+async function fetchSessionById(
+  supabase: SupabaseClient,
+  id: string
+): Promise<AskSessionRecord | null> {
+  const { data, error } = await supabase
+    .from("ask_sessions")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  if (!data) return null;
+  return fromRow(data as AskSessionRow);
+}
+
+/**
+ * Factory kept so tests can inject a stub Supabase client + userId without
+ * going through the SupabaseContext. Consumers in app code use the default
+ * `useSessions` export below.
+ */
+export function createUseSessions(deps: {
+  supabase: SupabaseClient;
+  userId: string;
+}) {
+  const { supabase, userId } = deps;
+  return function useSessions(): UseSessionsApi {
+    const queryClient = useQueryClient();
+    const key = useMemo(() => sessionsKey(userId), []);
+
+    const query = useQuery<AskSessionSummary[], Error>({
+      queryKey: key,
+      queryFn: () => fetchSessions(supabase, userId),
+    });
+
+    const invalidate = useCallback(
+      () => queryClient.invalidateQueries({ queryKey: key }),
+      [queryClient, key]
+    );
+
+    const createMutation = useMutation({
+      mutationFn: async (args: {
+        id: string;
+        title: string | null;
+        state: AskConversationState;
+      }) => {
+        const row = toRow({
+          id: args.id,
+          userId,
+          title: args.title,
+          isPublic: false,
+          state: args.state,
+        });
+        const { error } = await supabase.from("ask_sessions").insert(row);
+        if (error) throw new Error(error.message);
+      },
+      onSuccess: () => {
+        void invalidate();
+      },
+    });
+
+    const updateMutation = useMutation({
+      mutationFn: async (args: {
+        id: string;
+        patch: Partial<{
+          title: string | null;
+          isPublic: boolean;
+          state: AskConversationState;
+        }>;
+      }) => {
+        const dbPatch: Record<string, unknown> = {};
+        if ("title" in args.patch) dbPatch.title = args.patch.title ?? null;
+        if ("isPublic" in args.patch) dbPatch.is_public = args.patch.isPublic;
+        if (args.patch.state) {
+          const row = toRow({
+            id: args.id,
+            userId,
+            title: null,
+            isPublic: false,
+            state: args.patch.state,
+          });
+          dbPatch.messages = row.messages;
+          dbPatch.cards = row.cards;
+          dbPatch.model = row.model;
+        }
+        const { error } = await supabase
+          .from("ask_sessions")
+          .update(dbPatch)
+          .eq("id", args.id);
+        if (error) throw new Error(error.message);
+      },
+      onSuccess: () => {
+        void invalidate();
+      },
+    });
+
+    const removeMutation = useMutation({
+      mutationFn: async (id: string) => {
+        const { error } = await supabase
+          .from("ask_sessions")
+          .delete()
+          .eq("id", id);
+        if (error) throw new Error(error.message);
+      },
+      onSuccess: () => {
+        void invalidate();
+      },
+    });
+
+    const list = useCallback(async () => {
+      await queryClient.refetchQueries({ queryKey: key });
+    }, [queryClient, key]);
+
+    const get = useCallback(async (id: string) => {
+      return fetchSessionById(supabase, id);
+    }, []);
+
+    const create = useCallback<UseSessionsApi["create"]>(
+      async (args) => {
+        await createMutation.mutateAsync(args);
+      },
+      [createMutation]
+    );
+
+    const update = useCallback<UseSessionsApi["update"]>(
+      async (id, patch) => {
+        await updateMutation.mutateAsync({ id, patch });
+      },
+      [updateMutation]
+    );
+
+    const remove = useCallback(
+      async (id: string) => {
+        await removeMutation.mutateAsync(id);
+      },
+      [removeMutation]
+    );
+
+    const mutationError =
+      createMutation.error?.message ??
+      updateMutation.error?.message ??
+      removeMutation.error?.message ??
+      null;
+    const error = query.error?.message ?? mutationError ?? null;
+
+    return {
+      sessions: query.data,
+      error,
+      list,
+      get,
+      create,
+      update,
+      remove,
+    };
+  };
+}
+
+export function useSessions(): UseSessionsApi {
+  const ctx = useSupabaseContext();
+  if (!ctx.user) {
+    throw new Error("useSessions requires an authenticated user");
+  }
+  return createUseSessions({ supabase: ctx.client, userId: ctx.user.id })();
+}
+
+/**
+ * Helper for forcibly refreshing the sessions cache outside the hook (e.g.
+ * after a fork from the shared-view page). Rarely needed.
+ */
+export function invalidateSessions(
+  queryClient: QueryClient,
+  userId: string
+): void {
+  void queryClient.invalidateQueries({ queryKey: sessionsKey(userId) });
+}
+```
+
+Notes on this step: the external API (`UseSessionsApi`) is unchanged, so `ask.tsx` and `AskLayout.tsx` keep compiling without further edits. `list()` is kept for parity; it now force-refetches the shared query. `get()` still bypasses the cache (it reads a full record with `state`, which the list cache doesn't hold).
+
+- [ ] **Step 2: Update the unit tests to provide a QueryClientProvider**
+
+Open `client/src/hooks/__tests__/useSessions.test.ts`. Replace the whole file with:
+
+```tsx
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { createUseSessions } from "@/hooks/useSessions";
+
+interface Builder {
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  order: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  single: ReturnType<typeof vi.fn>;
+  maybeSingle: ReturnType<typeof vi.fn>;
+}
+
+function makeClient(rows: unknown[] = []) {
+  const builder = {} as Builder;
+  builder.select = vi.fn(() => builder);
+  builder.eq = vi.fn(() => builder);
+  builder.order = vi.fn(() => Promise.resolve({ data: rows, error: null }));
+  builder.insert = vi.fn(() =>
+    Promise.resolve({ data: rows[0] ?? null, error: null })
+  );
+  builder.update = vi.fn(() => builder);
+  builder.delete = vi.fn(() => builder);
+  builder.single = vi.fn(() =>
+    Promise.resolve({ data: rows[0] ?? null, error: null })
+  );
+  builder.maybeSingle = vi.fn(() =>
+    Promise.resolve({ data: rows[0] ?? null, error: null })
+  );
+  const from = vi.fn(() => builder);
+  return { client: { from }, from, builder };
+}
+
+function wrapperFactory() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  const Wrapper: React.FC<{ children: React.ReactNode }> = ({ children }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children
+    );
+  return { wrapper: Wrapper, queryClient };
+}
+
+describe("useSessions", () => {
+  it("list() queries ask_sessions ordered by updated_at desc for the user", async () => {
+    const { client, from, builder } = makeClient([]);
+    const { wrapper } = wrapperFactory();
+    const useHook = createUseSessions({
+      supabase: client as never,
+      userId: "u1",
+    });
+    const hook = renderHook(() => useHook(), { wrapper });
+    await waitFor(() =>
+      expect(hook.result.current.sessions).not.toBeUndefined()
+    );
+    expect(from).toHaveBeenCalledWith("ask_sessions");
+    expect(builder.select).toHaveBeenCalled();
+    expect(builder.eq).toHaveBeenCalledWith("user_id", "u1");
+    expect(builder.order).toHaveBeenCalledWith("updated_at", {
+      ascending: false,
+    });
+  });
+
+  it("create() inserts a row with toRow()-shaped payload", async () => {
+    const { client, builder } = makeClient();
+    const { wrapper } = wrapperFactory();
+    const useHook = createUseSessions({
+      supabase: client as never,
+      userId: "u1",
+    });
+    const hook = renderHook(() => useHook(), { wrapper });
+    await hook.result.current.create({
+      id: "11111111-1111-1111-1111-111111111111",
+      title: "Hello",
+      state: {
+        model: "m",
+        cards: {},
+        messages: [{ id: "u", role: "user", content: "hi" }],
+      },
+    });
+    expect(builder.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "11111111-1111-1111-1111-111111111111",
+        user_id: "u1",
+        title: "Hello",
+        is_public: false,
+        model: "m",
+      })
+    );
+  });
+
+  it("update(id, {isPublic}) sends is_public patch", async () => {
+    const { client, builder } = makeClient();
+    const { wrapper } = wrapperFactory();
+    const useHook = createUseSessions({
+      supabase: client as never,
+      userId: "u1",
+    });
+    const hook = renderHook(() => useHook(), { wrapper });
+    await hook.result.current.update("abc", { isPublic: true });
+    expect(builder.update).toHaveBeenCalledWith(
+      expect.objectContaining({ is_public: true })
+    );
+    expect(builder.eq).toHaveBeenCalledWith("id", "abc");
+  });
+
+  it("remove() deletes by id", async () => {
+    const { client, builder } = makeClient();
+    const { wrapper } = wrapperFactory();
+    const useHook = createUseSessions({
+      supabase: client as never,
+      userId: "u1",
+    });
+    const hook = renderHook(() => useHook(), { wrapper });
+    await hook.result.current.remove("abc");
+    expect(builder.delete).toHaveBeenCalled();
+    expect(builder.eq).toHaveBeenCalledWith("id", "abc");
+  });
+
+  it("mutations invalidate the shared sessions query (both consumers see the update)", async () => {
+    // Two renderHook calls sharing a QueryClient simulate AskLayout + AskPage.
+    const { client, builder } = makeClient([]);
+    const { wrapper } = wrapperFactory();
+    const useHook = createUseSessions({
+      supabase: client as never,
+      userId: "u1",
+    });
+    const a = renderHook(() => useHook(), { wrapper });
+    const b = renderHook(() => useHook(), { wrapper });
+
+    await waitFor(() => expect(a.result.current.sessions).not.toBeUndefined());
+    await waitFor(() => expect(b.result.current.sessions).not.toBeUndefined());
+
+    // Reset call counts from the initial load.
+    builder.order.mockClear();
+
+    await a.result.current.create({
+      id: "11111111-1111-1111-1111-111111111111",
+      title: "Hello",
+      state: { model: "m", cards: {}, messages: [] },
+    });
+
+    // Both hooks should have triggered a refetch via the shared cache.
+    await waitFor(() => expect(builder.order).toHaveBeenCalled());
+  });
+});
+```
+
+- [ ] **Step 3: Run tests and typecheck**
+
+Run: `cd client && npm run typecheck && npm test`
+Expected: typecheck clean, all tests pass (including the new shared-cache test).
+
+- [ ] **Step 4: Manual verification**
+
+Run `cd client && npm run dev`. Open `/ask` in a single tab and:
+1. Create a new chat from the empty state. The sidebar's session list should immediately show the new row (no manual refresh).
+2. Click `⋯` → Delete on a session. The sidebar row should disappear right away.
+3. Rename a session via `⋯` → Rename. The sidebar should reflect the new title.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/src/hooks/useSessions.ts client/src/hooks/__tests__/useSessions.test.ts
+git commit -m "ask: back useSessions with react-query so sidebar and page share one cache"
+```
+
+---
+
+## Task 10: Wire dropdown Share → flip public + copy + toast
+
+**Files:**
+- Modify: `client/src/components/ask/AskLayout.tsx`
+
+The `onShare` placeholder from Task 5 now gets real behavior. This task depends on sonner (Task 1) and on the shared-cache `useSessions` (Task 9).
+
+- [ ] **Step 1: Add a helper for the shareable link**
+
+Open `client/src/components/ask/AskLayout.tsx`. Replace the whole file with:
+
+```tsx
+import { Outlet, useParams } from "react-router-dom";
+import { toast } from "sonner";
+import { AuthGate } from "@/components/ask/AuthGate";
+import { SessionsSidebar } from "@/components/ask/SessionsSidebar";
+import { useSessions } from "@/hooks/useSessions";
+
+export function AskLayout() {
+  return (
+    <AuthGate>
+      <LayoutInner />
+    </AuthGate>
+  );
+}
+
+function shareUrlFor(sessionId: string): string {
+  return `${window.location.origin}${window.location.pathname}#/ask/s/${sessionId}`;
+}
+
+function LayoutInner() {
+  const { sessionId } = useParams<{ sessionId?: string }>();
+  const sessions = useSessions();
+
+  return (
+    <div className="flex h-full">
+      <SessionsSidebar
+        sessions={sessions.sessions ?? []}
+        activeId={sessionId ?? null}
+        onRename={(id) => {
+          const nextTitle = window.prompt("New title?");
+          if (nextTitle !== null && nextTitle.trim() !== "") {
+            sessions.update(id, { title: nextTitle.trim() });
+          }
+        }}
+        onDelete={(id) => {
+          if (
+            window.confirm("Delete this session? Any public link will 404.")
+          ) {
+            sessions.remove(id);
+          }
+        }}
+        onShare={async (id) => {
+          const session = sessions.sessions?.find((s) => s.id === id);
+          const wasPublic = session?.isPublic === true;
+          try {
+            if (!wasPublic) {
+              await sessions.update(id, { isPublic: true });
+            }
+            await navigator.clipboard.writeText(shareUrlFor(id));
+            toast.success(
+              wasPublic ? "Link copied" : "Link copied. Session is public now"
+            );
+          } catch (err) {
+            toast.error(
+              `Couldn't share: ${(err as Error).message ?? "unknown error"}`
+            );
+          }
+        }}
+      />
+      <div className="flex-1 min-w-0">
+        <Outlet />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd client && npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 3: Manual verification**
+
+Run `cd client && npm run dev`. In the sidebar:
+1. On a **private** session, click `⋯` → Share. A toast appears: "Link copied. Session is public now." The session's badge in the session header (when open) flips to "Shared". The clipboard contains the `/ask/s/<id>` URL.
+2. On an already-**public** session, click `⋯` → Share. Toast: "Link copied." No state change.
+3. In a clipboard-disabled context (or by denying clipboard permission) the error toast fires instead.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add client/src/components/ask/AskLayout.tsx
+git commit -m "ask: share from sidebar dropdown flips public, copies, toasts"
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Run the full client test suite and linter**
+
+Run:
+
+```bash
+cd client && npm run qa && npm test
+```
+
+Expected: lint clean, all tests pass.
+
+- [ ] **Step 2: Backend typecheck**
+
+Run:
+
+```bash
+cd backend && npm run typecheck
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: End-to-end smoke test**
+
+Start both servers (`cd backend && npm run dev`, then `cd client && npm run dev`). Walk through all nine fixes back-to-back:
+
+1. Empty `/ask` and an active `/ask/<id>` — both full-bleed, no double padding.
+2. Create session A, create session B, click back to A in sidebar — A's messages load.
+3. Dark mode: session titles, sticky header, citations panel — readable, no drift.
+4. Compare session `⋯` dropdown vs. ModelPicker — same label/separator hierarchy.
+5. Create a new chat and observe sidebar list updates without a refresh.
+6. Empty state + session view — no in-page "New chat" button (sidebar one only).
+7. Ask something that produces a graypaper citation; clicking "Open reader" opens the correct section.
+8. Session dropdown: no "Regenerate title" entry.
+9. Click `⋯` → Share on a private session: toast appears and the link is in the clipboard; the session is now public.
+
+- [ ] **Step 4: Push branch for review**
+
+```bash
+git push -u origin td-ask-ui-fixes
+```

--- a/docs/superpowers/specs/2026-04-24-ask-ui-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-24-ask-ui-fixes-design.md
@@ -86,7 +86,7 @@ Remove the menu item from `SessionRow`, the prop from `SessionsSidebar`, and the
 **Behavior:** Clicking the "Share" item in `SessionRow`'s dropdown:
 1. If the session is not public, calls `sessions.update(id, { isPublic: true })`.
 2. Copies the shareable link (`${origin}${pathname}#/ask/s/${id}`) to the clipboard.
-3. Shows a toast: "Link copied — made public" if we flipped it, "Link copied" if it was already public.
+3. Shows a toast: "Link copied. Session is public now" if we flipped it, "Link copied" if it was already public.
 
 **Toast infrastructure:** Add `sonner` dependency and mount `<Toaster />` in `App.tsx`. Lightweight, shadcn-native, matches the existing UI patterns.
 

--- a/docs/superpowers/specs/2026-04-24-ask-ui-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-24-ask-ui-fixes-design.md
@@ -46,7 +46,7 @@ if (createdRef.current.has(sessionId)) {
 
 **Fix:** Rewrite `useSessions` on top of `@tanstack/react-query` (already installed, already used by `useResults`, etc.). All consumers share the cache via `queryKey: ["ask_sessions", userId]`; mutations call `queryClient.invalidateQueries`.
 
-Side effect: removes the `createUseSessions(deps)()` factory, which was a workaround for needing `supabase`/`userId` in callbacks; react-query mutations close over those naturally.
+The existing `createUseSessions(deps)()` factory stays exported — tests inject a stub Supabase client and userId through it, so `useSessions()` (the default export) keeps delegating to it. The factory's hook body is what gets rewritten.
 
 API surface stays shape-compatible with the existing consumers:
 

--- a/docs/superpowers/specs/2026-04-24-ask-ui-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-24-ask-ui-fixes-design.md
@@ -1,0 +1,99 @@
+# /ask UI fixes — design
+
+Nine scoped fixes to the `/ask` feature: layout, session switching, dropdown parity, session list sync, link correctness, share UX.
+
+## 1. Padding consistency
+
+**Problem:** `App.tsx:96` sets `fullBleed = pathname === "/ask"`. Only the empty state skips the shell's `p-4`; `/ask/:sessionId` gets double padding.
+
+**Fix:** Widen the match so any `/ask` subpath is full-bleed, except the shared view (it renders its own `p-4 mx-auto max-w-5xl`).
+
+```ts
+const fullBleed = pathname === "/ask" || pathname.startsWith("/ask/");
+```
+
+`/ask/s/:id` is also `/ask/...`, which is fine: removing the outer `p-4` there just lets the shared page's internal padding stand alone, eliminating the existing double-pad.
+
+## 2. Session switching is broken
+
+**Problem:** `ask.tsx:64–69` has a `createdRef` that marks just-created session ids so we skip the initial hydrate round-trip. It never clears. Sequence *create A → switch to B → click A in sidebar* sees `createdRef.has(A)`, short-circuits with B still in state.
+
+**Fix:** Delete the entry after consuming it once:
+
+```ts
+if (createdRef.current.has(sessionId)) {
+  createdRef.current.delete(sessionId);
+  hydratedRef.current = sessionId;
+  return;
+}
+```
+
+## 3. Missing `text-foreground`
+
+**Problem:** `SessionsSidebar`'s `bg-card/50` aside and `SessionRow`'s link lack an explicit foreground color; they inherit from parents that may or may not resolve to a readable value in dark mode.
+
+**Fix:** Audit the `/ask` tree and add `text-foreground` only where color drifts — sidebar root, session row links, sticky header text. No shotgun sweep.
+
+## 4. Dropdown parity
+
+**Problem:** `ModelPicker` uses `DropdownMenuLabel` + `DropdownMenuSeparator` with muted styling, giving a clear hierarchy. `SessionRow`'s dropdown is bare items.
+
+**Fix:** Give `SessionRow`'s dropdown the same structural pattern (label row, separator, items). The "shared component" is the base `dropdown-menu.tsx` primitives — consolidate any styling defaults there so both pickers render consistently without wrapping in a second abstraction.
+
+## 5. Sessions randomly appear/disappear
+
+**Problem:** `useSessions()` is called twice — once in `AskLayout` (sidebar) and once in `AskPage` (page). Each instance has its own `useState`-backed `sessions` array. A mutation in one doesn't propagate to the other.
+
+**Fix:** Rewrite `useSessions` on top of `@tanstack/react-query` (already installed, already used by `useResults`, etc.). All consumers share the cache via `queryKey: ["ask_sessions", userId]`; mutations call `queryClient.invalidateQueries`.
+
+Side effect: removes the `createUseSessions(deps)()` factory, which was a workaround for needing `supabase`/`userId` in callbacks; react-query mutations close over those naturally.
+
+API surface stays shape-compatible with the existing consumers:
+
+```ts
+interface UseSessionsApi {
+  sessions: AskSessionSummary[] | undefined;
+  error: string | null;
+  list: () => Promise<void>;     // exposed for parity; mostly unused after refactor
+  get: (id: string) => Promise<AskSessionRecord | null>;
+  create: (...) => Promise<void>;
+  update: (...) => Promise<void>;
+  remove: (id: string) => Promise<void>;
+}
+```
+
+## 6. Remove "New chat" from the main section
+
+`ask.tsx:349–351` renders a "New chat" button in the sticky header. The sidebar already has one. Delete the button and its `handleNewChat` wiring if nothing else uses it.
+
+## 7. Graypaper link is wrong
+
+**Problem:** `buildGraypaperUrl(title)` in `backend/src/ask/tools.ts:50–53` produces `?section=${encodeURIComponent(title)}`. Search pages produce `?search=${query}&section=${section.title}` with no URL encoding. The Graypaper reader is broken for the /ask form.
+
+**Fix:** Match the search-page format byte-for-byte:
+- Plumb `args.query` from `executeSearchAll(args, …)` into `buildGraypaperUrl(title, query)`.
+- Emit `https://graypaper.fluffylabs.dev/#/?search=${query}&section=${title}` with no encoding (matches search pages).
+- For `executeGetFullDocument`, no query is available; pass an empty string so the URL is `?search=&section=${title}` (still valid per reader expectations).
+
+Parity with the existing search-results behavior is the correct baseline. If any section/query value contains `&` or `#` and breaks the hash route, that's a separate pre-existing bug affecting both the search UI and /ask equally.
+
+## 8. Remove "Regenerate title"
+
+Remove the menu item from `SessionRow`, the prop from `SessionsSidebar`, and the `onRegenerateTitle` handler in `AskLayout`. `requestTitle` remains used during initial creation in `ask.tsx`.
+
+## 9. Dropdown Share → flip public + copy + toast
+
+**Behavior:** Clicking the "Share" item in `SessionRow`'s dropdown:
+1. If the session is not public, calls `sessions.update(id, { isPublic: true })`.
+2. Copies the shareable link (`${origin}${pathname}#/ask/s/${id}`) to the clipboard.
+3. Shows a toast: "Link copied — made public" if we flipped it, "Link copied" if it was already public.
+
+**Toast infrastructure:** Add `sonner` dependency and mount `<Toaster />` in `App.tsx`. Lightweight, shadcn-native, matches the existing UI patterns.
+
+`SharePopover` on the session header stays as-is for the "make private again" affordance.
+
+## Out of scope
+
+- Streaming-during-switch race (dispatches from an aborted stream for session A arriving after hydrate of B).
+- Pre-existing bug where graypaper section titles with `&`/`#` break the reader's hash route.
+- Real-time multi-tab session sync (a user modifying sessions in another tab still won't see updates without a refetch).

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.14.0",
         "remark-gfm": "^4.0.1",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2",
         "tw-animate-css": "^1.4.0",
@@ -9980,6 +9981,16 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",


### PR DESCRIPTION
## Summary

Addresses nine UI/UX defects on `/ask`. Spec and plan are committed at `docs/superpowers/specs/2026-04-24-ask-ui-fixes-design.md` and `docs/superpowers/plans/2026-04-24-ask-ui-fixes.md`. One commit per fix so each change is independently reviewable.

- **Padding** — `fullBleed` now matches any `/ask` subroute; session and shared views no longer double-pad.
- **Session switching** — `createdRef` is consumed on first use, so *create A → visit B → click back A* re-hydrates from DB instead of keeping B's state.
- **Missing `text-foreground`** — added where drift was visible (sidebar aside, session row, `/ask` shells, citations aside).
- **Dropdown parity** — `SessionRow`'s menu now uses `DropdownMenuLabel` + `DropdownMenuSeparator` to match `ModelPicker`.
- **Session list sync** — `useSessions` moved to `@tanstack/react-query` with a shared `["ask_sessions", userId]` cache, so sidebar and page now observe the same data after any mutation.
- **Removed "Regenerate title"** from the session dropdown.
- **Removed in-page "New chat"** — sidebar already has it; session header now only renders when there's a `SharePopover` to show.
- **Graypaper link** — backend `buildGraypaperUrl` now emits `?search=<q>&section=<title>` to match the search-page format so the reader's hash router resolves.
- **Dropdown Share** — one click flips the session public (if needed), copies the link, and toasts `"Link copied"` / `"Link copied. Session is public now"`. Added `sonner` for toasts; mounted `<Toaster />` in `App.tsx`.
- **Bonus (follow-up):** `askShared.tsx::forkAndGo` now calls `invalidateSessions(queryClient, userId)` after the direct insert, so a forked session appears in the sidebar immediately instead of after a stale-time refetch.

## Test plan

- [ ] `npm run qa` at repo root — clean (lint + biome).
- [ ] `npm test` in `client/` — 82/82 pass.
- [ ] `npm run typecheck` in both `client/` and `backend/` — clean.
- [ ] Manual: `/ask` empty state and `/ask/:id` both full-bleed, no double padding.
- [ ] Manual: create session A, create B, click A in sidebar — A's messages load.
- [ ] Manual: sidebar reflects create/rename/delete without a refresh.
- [ ] Manual: graypaper citation's "Open reader" lands on the correct section.
- [ ] Manual: session dropdown matches ModelPicker hierarchy; no "Regenerate title"; no duplicate "New chat" in session header.
- [ ] Manual: dropdown Share on a private session → toast `"Link copied. Session is public now"`, link in clipboard.
- [ ] Manual: open a public `/ask/s/:id` as a logged-in user and fork — sidebar shows the fork immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global toast notifications for sharing/copy feedback; share action copies a link and can mark a session public.
* **Improvements**
  * Sessions now use a shared query-backed cache with optimistic updates for snappier UI.
  * Full-bleed layout applies to nested /ask routes; sidebar/search UI and text colors improved.
  * Dropdown visuals and source panel rendering refined.
* **Bug Fixes**
  * Fixed session-switch hydration and Graypaper links now preserve search context when applicable.
* **Removed**
  * "Regenerate title" menu option and duplicate "New chat" button
* **Tests**
  * Expanded tests for shared-cache, optimistic updates, and filtering behavior
* **Documentation**
  * Added implementation plan and design spec for /ask UI fixes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->