### PR TITLE
docker: install ca-certificates for on-start data fetch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,9 @@ WORKDIR /app
 EXPOSE 3000
 
 # git is required for on-start data fetching (see backend/src/data/fetcher.ts).
+# ca-certificates is required for git's HTTPS clone to verify the GitHub cert.
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends git \
+  && apt-get install -y --no-install-recommends git ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
 # Copy all source files and install dependencies


### PR DESCRIPTION
## Summary

- The `node:25-slim` base image omits CA certificates, and `git` doesn't pull them in transitively. The on-start data fetcher added in #243 fails its HTTPS clone with `server certificate verification failed. CAfile: none CRLfile: none`, crashing the backend at startup.
- Adds `ca-certificates` to the same `apt-get install` line that pulls in `git`.

## Test plan

- [ ] Build the image: `docker build -t jam-search .`
- [ ] Run it and confirm the backend logs `Fetched data.` instead of the cert verification error
- [ ] Confirm `/api/...` endpoints respond once startup completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to ensure secure HTTPS connectivity by including necessary certificate authorities for external package operations.

* **Documentation**
  * Clarified documentation regarding HTTPS certificate verification requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->