### PR TITLE
fetcher: fix EXDEV crash under Docker volume mounts

### DIFF
--- a/backend/src/__tests__/data/fetcher.test.ts
+++ b/backend/src/__tests__/data/fetcher.test.ts
@@ -177,6 +177,47 @@ describe("fetchData — happy path", () => {
   });
 });
 
+describe("fetchData — Docker volume mount semantics", () => {
+  // Regression for EXDEV crash in Docker: when /app/data is a bind/volume
+  // mount, fetcher cannot create siblings of dataDir (different filesystem
+  // and/or unwritable parent). It must do all rename work *inside* dataDir.
+  // chmod-ing the parent read-only is a portable analogue of that constraint.
+  const skip =
+    process.platform === "win32" ||
+    (typeof process.getuid === "function" && process.getuid() === 0);
+  it.skipIf(skip)(
+    "succeeds when the parent of dataDir is unwritable (mount-point analogue)",
+    async () => {
+      const fixture = await makeFixtureRepo({
+        dataFiles: { "a.md": "hello", "sub/b.md": "world" },
+      });
+      const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "fetcher-mount-"));
+      const dataDir = path.join(workDir, "data");
+      fs.mkdirSync(dataDir, { recursive: true });
+      fs.writeFileSync(path.join(dataDir, "stale.md"), "stale");
+      fs.chmodSync(workDir, 0o555);
+      try {
+        await fetchData({
+          repoUrl: fixture.bareUrl,
+          ref: "main",
+          dataDir,
+        });
+        expect(fs.readFileSync(path.join(dataDir, "a.md"), "utf-8")).toBe(
+          "hello"
+        );
+        expect(fs.readFileSync(path.join(dataDir, "sub/b.md"), "utf-8")).toBe(
+          "world"
+        );
+        expect(fs.existsSync(path.join(dataDir, "stale.md"))).toBe(false);
+      } finally {
+        fs.chmodSync(workDir, 0o755);
+        fs.rmSync(workDir, { recursive: true, force: true });
+        fixture.cleanup();
+      }
+    }
+  );
+});
+
 describe("fetchData — errors", () => {
   it("throws with git stderr when the ref does not exist", async () => {
     const fixture = await makeFixtureRepo({

--- a/backend/src/data/fetcher.ts
+++ b/backend/src/data/fetcher.ts
@@ -57,9 +57,21 @@ export async function fetchData(opts: FetchDataOptions): Promise<void> {
   const resolvedDataDir = assertSafeDataDir(opts.dataDir);
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
+  // Stage everything *inside* resolvedDataDir so all rename(2) calls stay on
+  // the same filesystem. Required when resolvedDataDir is a mount point
+  // (Docker volume / bind mount): the mount itself can't be renamed, and
+  // crossing the mount boundary fails with EXDEV.
   const parentDir = path.dirname(resolvedDataDir);
   await fsp.mkdir(parentDir, { recursive: true });
-  const tmp = await fsp.mkdtemp(path.join(parentDir, ".data-fetch-"));
+  let createdDataDir = false;
+  try {
+    await fsp.mkdir(resolvedDataDir);
+    createdDataDir = true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+  }
+  const tmp = await fsp.mkdtemp(path.join(resolvedDataDir, ".data-fetch-"));
+  let succeeded = false;
 
   try {
     await git(["init", "-q"], tmp, timeoutMs);
@@ -76,24 +88,50 @@ export async function fetchData(opts: FetchDataOptions): Promise<void> {
       );
     }
 
-    // Atomic swap
-    const backup = `${resolvedDataDir}.old-${process.pid}`;
-    const hadExisting = fs.existsSync(resolvedDataDir);
-    if (hadExisting) {
-      await fsp.rename(resolvedDataDir, backup);
+    await swapDirContents(resolvedDataDir, fetchedData, path.basename(tmp));
+    succeeded = true;
+  } finally {
+    await fsp.rm(tmp, { recursive: true, force: true });
+    if (!succeeded && createdDataDir) {
+      await fsp.rmdir(resolvedDataDir).catch(() => {});
+    }
+  }
+}
+
+// Replace the top-level entries of `target` with the top-level entries of
+// `source`. Operates only on `target`'s children — never on `target` itself —
+// so it works when `target` is a mount point. `excludeFromTarget` is the
+// basename of an entry in `target` that must be left in place (the staging
+// dir holding the new data).
+async function swapDirContents(
+  target: string,
+  source: string,
+  excludeFromTarget: string
+): Promise<void> {
+  const backupDir = await fsp.mkdtemp(path.join(target, ".data-backup-"));
+  const backupName = path.basename(backupDir);
+  try {
+    const existing = (await fsp.readdir(target)).filter(
+      (e) => e !== excludeFromTarget && e !== backupName
+    );
+    for (const entry of existing) {
+      await fsp.rename(path.join(target, entry), path.join(backupDir, entry));
     }
     try {
-      await fsp.rename(fetchedData, resolvedDataDir);
+      const newEntries = await fsp.readdir(source);
+      for (const entry of newEntries) {
+        await fsp.rename(path.join(source, entry), path.join(target, entry));
+      }
     } catch (err) {
-      if (hadExisting) {
-        await fsp.rename(backup, resolvedDataDir).catch(() => {});
+      const restored = await fsp.readdir(backupDir);
+      for (const entry of restored) {
+        await fsp
+          .rename(path.join(backupDir, entry), path.join(target, entry))
+          .catch(() => {});
       }
       throw err;
     }
-    if (hadExisting) {
-      await fsp.rm(backup, { recursive: true, force: true });
-    }
   } finally {
-    await fsp.rm(tmp, { recursive: true, force: true });
+    await fsp.rm(backupDir, { recursive: true, force: true });
   }
 }


### PR DESCRIPTION
## Summary

- Fixes the on-start crash `Error: EXDEV: cross-device link not permitted, rename '/app/data' -> '/app/data.old-<pid>'` when the container is run with a volume / bind mount on `/app/data`.
- Root cause: `fetchData` did an atomic dir-level swap via `fs.rename`. When `dataDir` is a Docker mount, `rename(2)` cannot cross the mount boundary (EXDEV), and the mount point itself can't be renamed at all.
- Fix: stage the git checkout *inside* `dataDir` (same filesystem) and swap the directory's *children* via per-entry renames. The mount point is never touched, and a hidden `.data-backup-*` dir gives us rollback if any rename fails.

## Test plan

- [x] New regression test `succeeds when the parent of dataDir is unwritable (mount-point analogue)` — chmods the parent read-only as a portable proxy for "can't create siblings of dataDir". Fails on the old code with `EACCES on mkdtemp`, passes on the new code. Skipped on Windows / when run as root.
- [x] All 9 pre-existing `fetcher.test.ts` cases still pass (happy path, errors, safety).
- [x] `npm -w backend test` — 86 tests pass.
- [x] `npm -w backend run typecheck` — clean.
- [ ] Manual: rebuild image and run with `docker run -v <vol>:/app/data ...` to confirm startup no longer crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data fetching reliability in environments with mounted filesystems and restricted write permissions, ensuring robust content management and proper cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->