### PR TITLE
fetcher: replace dir-rename swap with delete-then-copy

### DIFF
--- a/backend/src/data/fetcher.ts
+++ b/backend/src/data/fetcher.ts
@@ -103,35 +103,27 @@ export async function fetchData(opts: FetchDataOptions): Promise<void> {
 // so it works when `target` is a mount point. `excludeFromTarget` is the
 // basename of an entry in `target` that must be left in place (the staging
 // dir holding the new data).
+//
+// Uses delete-then-copy at file level: rename(2) of a directory can fail with
+// EXDEV in Docker even between siblings (overlayfs directory-rename
+// limitation), so we avoid renaming directories entirely. No backup/rollback —
+// data is reproducible from git, and a partial swap on failure just gets
+// re-fetched on the next start.
 async function swapDirContents(
   target: string,
   source: string,
   excludeFromTarget: string
 ): Promise<void> {
-  const backupDir = await fsp.mkdtemp(path.join(target, ".data-backup-"));
-  const backupName = path.basename(backupDir);
-  try {
-    const existing = (await fsp.readdir(target)).filter(
-      (e) => e !== excludeFromTarget && e !== backupName
-    );
-    for (const entry of existing) {
-      await fsp.rename(path.join(target, entry), path.join(backupDir, entry));
-    }
-    try {
-      const newEntries = await fsp.readdir(source);
-      for (const entry of newEntries) {
-        await fsp.rename(path.join(source, entry), path.join(target, entry));
-      }
-    } catch (err) {
-      const restored = await fsp.readdir(backupDir);
-      for (const entry of restored) {
-        await fsp
-          .rename(path.join(backupDir, entry), path.join(target, entry))
-          .catch(() => {});
-      }
-      throw err;
-    }
-  } finally {
-    await fsp.rm(backupDir, { recursive: true, force: true });
+  const existing = (await fsp.readdir(target)).filter(
+    (e) => e !== excludeFromTarget
+  );
+  for (const entry of existing) {
+    await fsp.rm(path.join(target, entry), { recursive: true, force: true });
+  }
+  const newEntries = await fsp.readdir(source);
+  for (const entry of newEntries) {
+    await fsp.cp(path.join(source, entry), path.join(target, entry), {
+      recursive: true,
+    });
   }
 }


### PR DESCRIPTION
## Summary

- Drop the backup/rollback dance in `swapDirContents` and stop renaming directories during the swap. We now `rm -rf` existing children of `dataDir` and `fs.cp`-recursive the new ones in.
- Fixes a recurrence of EXDEV at startup in prod under `node:25-slim` + Docker overlayfs:

  ```
  EXDEV: cross-device link not permitted, rename '/app/data/code' -> '/app/data/.data-backup-30i0SD/code'
  ```

  Both paths are siblings under `/app/data` (single overlay layer, no nested mount — confirmed: `docker run -v jam-search-cache:/app/cache …` is the only volume). The overlayfs storage driver can return EXDEV on `rename(2)` of a directory even within the same writable layer (directory-rename limitation). The previous fix (#252) staged inside `dataDir` so renames don't cross the parent boundary, but it still relied on directory rename for the swap, which is what overlayfs is rejecting on container restart when `/app/data` already has children.

- No backup/rollback. `fetchData` runs once at startup before any reader; the data is fully reproducible from git, so a partial swap on failure just gets re-fetched on the next start.

## Test plan
- [x] `npx vitest run backend/src/__tests__/data/fetcher.test.ts` — all 10 tests pass, including the "mount-point analogue" parent-read-only regression test from #252.
- [x] `npm run typecheck` clean.
- [ ] Deploy to the affected container (`docker run … ghcr.io/fluffylabs/jam-search/backend`) and confirm startup completes without EXDEV on a non-empty `/app/data`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to directory handling operations for better reliability and simplified logic.

---

**Note:** This release contains internal improvements with no user-facing feature changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->