### PR TITLE
embeddings: cap batches by token count, not just item count

### DIFF
--- a/backend/src/__tests__/data/embeddings.test.ts
+++ b/backend/src/__tests__/data/embeddings.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { buildBatches } from "../../data/embeddings.js";
+import type { SearchDoc } from "../../data/searchIndex.js";
+
+function makeItem(text: string, id = "x") {
+  return {
+    doc: { id } as SearchDoc,
+    key: id,
+    text,
+  };
+}
+
+describe("buildBatches", () => {
+  it("returns no batches for empty input", () => {
+    expect(buildBatches([])).toEqual([]);
+  });
+
+  it("packs all items into one batch when both caps allow it", () => {
+    const items = [makeItem("a"), makeItem("b"), makeItem("c")];
+    const batches = buildBatches(items, 10, 1000);
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(3);
+  });
+
+  it("splits when item-count cap is exceeded", () => {
+    const items = Array.from({ length: 7 }, (_, i) => makeItem("a", `id${i}`));
+    const batches = buildBatches(items, 3, 1_000_000);
+    expect(batches.map((b) => b.length)).toEqual([3, 3, 1]);
+  });
+
+  it("splits when token cap would be exceeded", () => {
+    // Each text is 400 chars => ~100 estimated tokens.
+    // Token cap = 250 means at most 2 items per batch.
+    const items = Array.from({ length: 5 }, (_, i) =>
+      makeItem("x".repeat(400), `id${i}`)
+    );
+    const batches = buildBatches(items, 1000, 250);
+    expect(batches.map((b) => b.length)).toEqual([2, 2, 1]);
+  });
+
+  it("never produces an empty batch even when a single item exceeds the token cap", () => {
+    // One huge item alone would exceed the cap; it must still be sent in its
+    // own batch rather than dropped or producing an empty batch.
+    const items = [
+      makeItem("x".repeat(2000), "huge"),
+      makeItem("small", "small"),
+    ];
+    const batches = buildBatches(items, 1000, 100);
+    expect(batches).toHaveLength(2);
+    expect(batches[0]).toHaveLength(1);
+    expect(batches[0][0].key).toBe("huge");
+    expect(batches[1]).toHaveLength(1);
+    expect(batches[1][0].key).toBe("small");
+  });
+
+  it("respects the production batch — a 500-item batch of 20k-char docs splits", () => {
+    // This is the exact production scenario that triggered the OpenAI 300k-token
+    // error: 500 items each carrying up to 20k chars (~5k estimated tokens) would
+    // be ~2.5M tokens in one request. The token cap must split them.
+    const items = Array.from({ length: 500 }, (_, i) =>
+      makeItem("x".repeat(20_000), `id${i}`)
+    );
+    const batches = buildBatches(items);
+    // Each item is ~5000 tokens; cap is 250k; expect ~50 items per batch.
+    expect(batches.length).toBeGreaterThan(1);
+    for (const batch of batches) {
+      const totalChars = batch.reduce((sum, b) => sum + b.text.length, 0);
+      expect(Math.ceil(totalChars / 4)).toBeLessThanOrEqual(250_000);
+    }
+    // No items lost.
+    const total = batches.reduce((sum, b) => sum + b.length, 0);
+    expect(total).toBe(500);
+  });
+});

--- a/backend/src/data/embeddings.ts
+++ b/backend/src/data/embeddings.ts
@@ -6,7 +6,16 @@ import type { SearchDoc } from "./searchIndex.js";
 
 const EMBEDDING_MODEL = "text-embedding-3-small";
 const EMBEDDING_DIMENSIONS = 1536;
-const BATCH_SIZE = 500; // Keep batches small for faster individual requests
+const MAX_ITEMS_PER_BATCH = 500; // Keep batches small for faster individual requests
+// OpenAI enforces 300k tokens per request for text-embedding-3-*; stay well under
+// to absorb the inaccuracy of the chars/4 token estimate.
+const MAX_TOKENS_PER_BATCH = 250_000;
+// Rough heuristic: ~4 chars per token for English/code. Conservative for safety.
+const CHARS_PER_TOKEN = 4;
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
 
 interface EmbeddingsCache {
   [key: string]: number[];
@@ -29,6 +38,44 @@ function embeddingText(doc: SearchDoc): string {
   if (doc.sender) parts.push(`${doc.sender}:`);
   if (doc.content) parts.push(doc.content.slice(0, 20000));
   return parts.join("\n");
+}
+
+interface PendingEmbedding {
+  doc: SearchDoc;
+  key: string;
+  text: string;
+}
+
+export function buildBatches(
+  items: PendingEmbedding[],
+  maxItems: number = MAX_ITEMS_PER_BATCH,
+  maxTokens: number = MAX_TOKENS_PER_BATCH
+): PendingEmbedding[][] {
+  const batches: PendingEmbedding[][] = [];
+  let current: PendingEmbedding[] = [];
+  let currentTokens = 0;
+
+  for (const item of items) {
+    const tokens = estimateTokens(item.text);
+    const wouldExceed =
+      current.length >= maxItems ||
+      (current.length > 0 && currentTokens + tokens > maxTokens);
+
+    if (wouldExceed) {
+      batches.push(current);
+      current = [];
+      currentTokens = 0;
+    }
+
+    current.push(item);
+    currentTokens += tokens;
+  }
+
+  if (current.length > 0) {
+    batches.push(current);
+  }
+
+  return batches;
 }
 
 export function loadEmbeddingsCache(cacheDir: string): EmbeddingsCache {
@@ -96,14 +143,17 @@ export async function generateEmbeddings(
 
   const openai = new OpenAI({ apiKey: openaiApiKey });
 
-  // Process in batches
-  for (let i = 0; i < needsEmbedding.length; i += BATCH_SIZE) {
-    const batch = needsEmbedding.slice(i, i + BATCH_SIZE);
-    const batchNum = Math.floor(i / BATCH_SIZE) + 1;
-    const totalBatches = Math.ceil(needsEmbedding.length / BATCH_SIZE);
+  // Build batches that respect both an item-count cap and an estimated-token
+  // cap. The token cap protects against OpenAI's 300k-tokens-per-request limit,
+  // which a fixed item count cannot — a single 20k-char doc can be ~5k tokens.
+  const batches = buildBatches(needsEmbedding);
+
+  for (let batchIdx = 0; batchIdx < batches.length; batchIdx++) {
+    const batch = batches[batchIdx];
+    const batchNum = batchIdx + 1;
 
     console.log(
-      `Generating embeddings batch ${batchNum}/${totalBatches} (${batch.length} items)...`
+      `Generating embeddings batch ${batchNum}/${batches.length} (${batch.length} items)...`
     );
 
     try {


### PR DESCRIPTION
## Summary

- Production hit `BadRequestError: 400 Requested 436244 tokens, max 300000 tokens per request` when generating embeddings.
- Root cause: batches were sized by item count only (500), but `text-embedding-3-small` enforces a 300k-token-per-request cap. Each item in a batch can carry up to ~5k tokens (20k-char content slice), so a 500-item batch could approach 2.5M tokens.
- Fix: token-aware batcher (`buildBatches`) that caps each batch at both 500 items and 250k estimated tokens (chars/4), with the 250k limit leaving headroom under the 300k cap to absorb estimate inaccuracy.

## Test plan

- [x] New unit tests in `backend/src/__tests__/data/embeddings.test.ts` — 6 cases including the exact production scenario (500 × 20k-char docs).
- [x] Full backend test suite: 92/92 pass.
- [x] `npm run typecheck` clean.
- [ ] Verify on next production indexing run that no `max_tokens_per_request` errors occur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized embedding batch processing with enhanced resource constraint management for better batch sizing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->