### PR TITLE
graypaper: pin reader URLs to latest hash + version

### DIFF
--- a/backend/src/__tests__/ask/tools.test.ts
+++ b/backend/src/__tests__/ask/tools.test.ts
@@ -70,7 +70,7 @@ describe("executeGetFullDocument", () => {
       content: "Full body of the accumulate section...",
     });
 
-    const result = await executeGetFullDocument({ id }, db);
+    const result = await executeGetFullDocument({ id }, db, "./data");
 
     expect(result).not.toBeNull();
     expect(result?.sourceType).toBe("graypaper");
@@ -79,7 +79,11 @@ describe("executeGetFullDocument", () => {
 
   it("returns null for an unknown id", async () => {
     const db = createSearchDB();
-    const result = await executeGetFullDocument({ id: "does-not-exist" }, db);
+    const result = await executeGetFullDocument(
+      { id: "does-not-exist" },
+      db,
+      "./data"
+    );
     expect(result).toBeNull();
   });
 });

--- a/backend/src/__tests__/data/graypaperLatest.test.ts
+++ b/backend/src/__tests__/data/graypaperLatest.test.ts
@@ -1,0 +1,116 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  getGraypaperLatest,
+  resetGraypaperLatestCache,
+} from "../../data/graypaperLatest.js";
+import { writeGraypaperVersions } from "../../data/writer.js";
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "graypaper-latest-"));
+}
+
+describe("getGraypaperLatest", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    resetGraypaperLatestCache();
+    dataDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("returns the persisted latest hash and version", () => {
+    writeGraypaperVersions(
+      dataDir,
+      [{ version: "0.7.2", timestamp: new Date("2025-09-15") }],
+      { hash: "ab2cdbd5b070ba2176e8dd830b06401ce05a954d", version: "0.7.2" }
+    );
+
+    expect(getGraypaperLatest(dataDir)).toEqual({
+      hash: "ab2cdbd5b070ba2176e8dd830b06401ce05a954d",
+      version: "0.7.2",
+    });
+  });
+
+  it("returns nulls when versions.md is absent", () => {
+    expect(getGraypaperLatest(dataDir)).toEqual({ hash: null, version: null });
+  });
+
+  it("invalidates cache when versions.md mtime changes", () => {
+    writeGraypaperVersions(
+      dataDir,
+      [{ version: "0.7.2", timestamp: new Date("2025-09-15") }],
+      { hash: "aaaaaaaaaaaa", version: "0.7.2" }
+    );
+    expect(getGraypaperLatest(dataDir).hash).toBe("aaaaaaaaaaaa");
+
+    // Out-of-process update: rewrite versions.md with a newer mtime.
+    const versionsPath = path.join(dataDir, "graypaper", "versions.md");
+    const futureMs = fs.statSync(versionsPath).mtimeMs + 5_000;
+    writeGraypaperVersions(
+      dataDir,
+      [{ version: "0.8.0", timestamp: new Date("2025-12-01") }],
+      { hash: "bbbbbbbbbbbb", version: "0.8.0" }
+    );
+    fs.utimesSync(versionsPath, futureMs / 1000, futureMs / 1000);
+
+    expect(getGraypaperLatest(dataDir)).toEqual({
+      hash: "bbbbbbbbbbbb",
+      version: "0.8.0",
+    });
+  });
+});
+
+describe("writeGraypaperVersions latest semantics", () => {
+  let dataDir: string;
+
+  beforeEach(() => {
+    resetGraypaperLatestCache();
+    dataDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it("preserves existing latest when called without the latest arg", () => {
+    writeGraypaperVersions(
+      dataDir,
+      [{ version: "0.7.2", timestamp: new Date("2025-09-15") }],
+      { hash: "preserved-hash", version: "0.7.2" }
+    );
+
+    // Re-write WITHOUT passing latest (simulates exportToMarkdown).
+    writeGraypaperVersions(dataDir, [
+      { version: "0.7.2", timestamp: new Date("2025-09-15") },
+    ]);
+
+    resetGraypaperLatestCache();
+    expect(getGraypaperLatest(dataDir)).toEqual({
+      hash: "preserved-hash",
+      version: "0.7.2",
+    });
+  });
+
+  it("clears the pin when called with latest=null", () => {
+    writeGraypaperVersions(
+      dataDir,
+      [{ version: "0.7.2", timestamp: new Date("2025-09-15") }],
+      { hash: "to-be-cleared", version: "0.7.2" }
+    );
+
+    writeGraypaperVersions(
+      dataDir,
+      [{ version: "0.7.2", timestamp: new Date("2025-09-15") }],
+      null
+    );
+
+    resetGraypaperLatestCache();
+    expect(getGraypaperLatest(dataDir)).toEqual({ hash: null, version: null });
+  });
+});

--- a/backend/src/api.ts
+++ b/backend/src/api.ts
@@ -19,6 +19,7 @@ import {
 } from "./api/searchMessages.js";
 import { searchPages, searchPagesRequestSchema } from "./api/searchPages.js";
 import { embeddingCache } from "./cache/embeddingCache.js";
+import { getGraypaperLatest } from "./data/graypaperLatest.js";
 import type { SearchDB } from "./data/searchIndex.js";
 import { createMcpHandler } from "./mcp/handler.js";
 
@@ -82,6 +83,10 @@ export function createApp(db: SearchDB, dataDir: string) {
   app.get("/search/graypaper", async (c) => {
     const data = searchGraypaperRequestSchema.parse(c.req.query());
     return c.json(await searchGraypaper(data, embeddingCache, db, dataDir));
+  });
+
+  app.get("/graypaper/latest", (c) => {
+    return c.json(getGraypaperLatest(dataDir));
   });
 
   app.post("/ask", handleAsk(db, dataDir));

--- a/backend/src/ask/agentLoop.ts
+++ b/backend/src/ask/agentLoop.ts
@@ -201,7 +201,11 @@ async function executeToolByName(
     return { resultCount: results.length, payload: results };
   }
   if (name === "get_full_document") {
-    const doc = await executeGetFullDocument({ id: String(a.id ?? "") }, db);
+    const doc = await executeGetFullDocument(
+      { id: String(a.id ?? "") },
+      db,
+      dataDir
+    );
     return { resultCount: doc ? 1 : 0, payload: doc ?? { error: "not found" } };
   }
   return {

--- a/backend/src/ask/tools.ts
+++ b/backend/src/ask/tools.ts
@@ -1,12 +1,14 @@
 import { getByID } from "@orama/orama";
 import OpenAI from "openai";
 import { z } from "zod";
+import { buildGraypaperUrl as composeGraypaperUrl } from "../../../shared/graypaper.js";
 import * as matrix from "../../../shared/matrix.js";
 import { searchDiscords } from "../api/searchDiscords.js";
 import { searchGraypaper } from "../api/searchGraypapers.js";
 import { searchMessages } from "../api/searchMessages.js";
 import { searchPages } from "../api/searchPages.js";
 import { embeddingCache } from "../cache/embeddingCache.js";
+import { getGraypaperLatest } from "../data/graypaperLatest.js";
 import type { DocType, SearchDB, SearchDoc } from "../data/searchIndex.js";
 import type { SourceType } from "./types.js";
 
@@ -49,12 +51,11 @@ function buildMatrixUrl(
 
 function buildGraypaperUrl(
   title: string | undefined,
-  query: string
+  query: string,
+  dataDir: string
 ): string | undefined {
   if (!title) return undefined;
-  // Match the search-results URL format byte-for-byte (no URL encoding).
-  // The Graypaper reader's hash router expects this exact shape.
-  return `https://graypaper.fluffylabs.dev/#/?search=${query}&section=${title}`;
+  return composeGraypaperUrl(title, query, getGraypaperLatest(dataDir));
 }
 
 /**
@@ -170,7 +171,7 @@ export async function executeSearchAll(
       sourceType: "graypaper",
       preview: truncate(r.text ?? ""),
       title: r.title,
-      url: buildGraypaperUrl(r.title, args.query),
+      url: buildGraypaperUrl(r.title, args.query, dataDir),
       score: r.score,
     });
   }
@@ -203,7 +204,7 @@ function docTypeToSourceType(type: DocType): SourceType {
   }
 }
 
-function resolveDocUrl(doc: SearchDoc): string | undefined {
+function resolveDocUrl(doc: SearchDoc, dataDir: string): string | undefined {
   switch (doc.type) {
     case "page":
       return doc.url;
@@ -220,13 +221,14 @@ function resolveDocUrl(doc: SearchDoc): string | undefined {
     case "graypaper_version":
       // No search query context here; fall back to empty query so the
       // reader still routes to the section.
-      return buildGraypaperUrl(doc.title, "");
+      return buildGraypaperUrl(doc.title, "", dataDir);
   }
 }
 
 export async function executeGetFullDocument(
   args: { id: string },
-  db: SearchDB
+  db: SearchDB,
+  dataDir: string
 ): Promise<FullDocument | null> {
   const doc = (await getByID(db, args.id)) as SearchDoc | undefined;
   if (!doc) return null;
@@ -235,7 +237,7 @@ export async function executeGetFullDocument(
     sourceType: docTypeToSourceType(doc.type),
     content: doc.content,
     title: doc.title,
-    url: resolveDocUrl(doc),
+    url: resolveDocUrl(doc, dataDir),
     sender: doc.sender,
     channelName: doc.channelName,
     roomName: doc.roomName,

--- a/backend/src/data/graypaperLatest.ts
+++ b/backend/src/data/graypaperLatest.ts
@@ -5,10 +5,25 @@ import type { GraypaperLatest } from "../../../shared/graypaper.js";
 
 const EMPTY: GraypaperLatest = { hash: null, version: null };
 
-let cache: { dataDir: string; value: GraypaperLatest } | null = null;
+let cache: {
+  dataDir: string;
+  mtimeMs: number | null;
+  value: GraypaperLatest;
+} | null = null;
 
-function readFromDisk(dataDir: string): GraypaperLatest {
-  const versionsPath = path.join(dataDir, "graypaper", "versions.md");
+function versionsPathOf(dataDir: string): string {
+  return path.join(dataDir, "graypaper", "versions.md");
+}
+
+function getMtime(versionsPath: string): number | null {
+  try {
+    return fs.statSync(versionsPath).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+function readFromDisk(versionsPath: string): GraypaperLatest {
   if (!fs.existsSync(versionsPath)) return EMPTY;
 
   const raw = fs.readFileSync(versionsPath, "utf-8");
@@ -19,11 +34,20 @@ function readFromDisk(dataDir: string): GraypaperLatest {
   };
 }
 
-/** Read the latest graypaper hash + version from versions.md, cached per dataDir. */
+/**
+ * Read the latest graypaper hash + version from versions.md.
+ * Cached per dataDir, invalidated when the file's mtime changes — needed
+ * because graypaperJob runs out-of-process and rewrites versions.md without
+ * the API server's knowledge.
+ */
 export function getGraypaperLatest(dataDir: string): GraypaperLatest {
-  if (cache && cache.dataDir === dataDir) return cache.value;
-  const value = readFromDisk(dataDir);
-  cache = { dataDir, value };
+  const versionsPath = versionsPathOf(dataDir);
+  const mtimeMs = getMtime(versionsPath);
+  if (cache && cache.dataDir === dataDir && cache.mtimeMs === mtimeMs) {
+    return cache.value;
+  }
+  const value = readFromDisk(versionsPath);
+  cache = { dataDir, mtimeMs, value };
   return value;
 }
 

--- a/backend/src/data/graypaperLatest.ts
+++ b/backend/src/data/graypaperLatest.ts
@@ -1,0 +1,33 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import matter from "gray-matter";
+import type { GraypaperLatest } from "../../../shared/graypaper.js";
+
+const EMPTY: GraypaperLatest = { hash: null, version: null };
+
+let cache: { dataDir: string; value: GraypaperLatest } | null = null;
+
+function readFromDisk(dataDir: string): GraypaperLatest {
+  const versionsPath = path.join(dataDir, "graypaper", "versions.md");
+  if (!fs.existsSync(versionsPath)) return EMPTY;
+
+  const raw = fs.readFileSync(versionsPath, "utf-8");
+  const { data: frontmatter } = matter(raw);
+  return {
+    hash: (frontmatter.latest_hash as string) ?? null,
+    version: (frontmatter.latest_version as string) ?? null,
+  };
+}
+
+/** Read the latest graypaper hash + version from versions.md, cached per dataDir. */
+export function getGraypaperLatest(dataDir: string): GraypaperLatest {
+  if (cache && cache.dataDir === dataDir) return cache.value;
+  const value = readFromDisk(dataDir);
+  cache = { dataDir, value };
+  return value;
+}
+
+/** Reset the in-memory cache. Used by tests. */
+export function resetGraypaperLatestCache(): void {
+  cache = null;
+}

--- a/backend/src/data/writer.ts
+++ b/backend/src/data/writer.ts
@@ -258,16 +258,39 @@ export function writeGraypaperSection(
   return relativePath;
 }
 
+/**
+ * Write the graypaper versions index.
+ *
+ * `latest` semantics — important because `matter.stringify` rewrites the
+ * frontmatter from scratch, so omitting a field deletes any persisted value:
+ *   - `undefined`: preserve whatever `latest_hash` / `latest_version` are
+ *     already on disk (used by callers that don't know about the pinned ref,
+ *     e.g. exportToMarkdown).
+ *   - `null`: clear the pinned ref (no metadata.latest available).
+ *   - `{hash, version}`: write the pinned ref.
+ */
 export function writeGraypaperVersions(
   dataDir: string,
   versions: Array<{ version: string; timestamp: Date }>,
-  latest?: { hash: string; version: string }
+  latest?: { hash: string; version: string } | null
 ): string {
   const dir = path.join(dataDir, "graypaper");
   ensureDir(dir);
 
   const filePath = path.join(dir, "versions.md");
   const relativePath = path.relative(dataDir, filePath);
+
+  let resolvedLatest: { hash: string; version: string } | null = null;
+  if (latest === undefined) {
+    if (fs.existsSync(filePath)) {
+      const existing = matter(fs.readFileSync(filePath, "utf-8")).data;
+      const hash = existing.latest_hash as string | undefined;
+      const version = existing.latest_version as string | undefined;
+      if (hash && version) resolvedLatest = { hash, version };
+    }
+  } else {
+    resolvedLatest = latest;
+  }
 
   const frontmatter: Record<string, unknown> = {
     type: "graypaper_versions",
@@ -276,9 +299,9 @@ export function writeGraypaperVersions(
       timestamp: v.timestamp.toISOString(),
     })),
   };
-  if (latest) {
-    frontmatter.latest_hash = latest.hash;
-    frontmatter.latest_version = latest.version;
+  if (resolvedLatest) {
+    frontmatter.latest_hash = resolvedLatest.hash;
+    frontmatter.latest_version = resolvedLatest.version;
   }
 
   const body = versions

--- a/backend/src/data/writer.ts
+++ b/backend/src/data/writer.ts
@@ -260,7 +260,8 @@ export function writeGraypaperSection(
 
 export function writeGraypaperVersions(
   dataDir: string,
-  versions: Array<{ version: string; timestamp: Date }>
+  versions: Array<{ version: string; timestamp: Date }>,
+  latest?: { hash: string; version: string }
 ): string {
   const dir = path.join(dataDir, "graypaper");
   ensureDir(dir);
@@ -268,13 +269,17 @@ export function writeGraypaperVersions(
   const filePath = path.join(dir, "versions.md");
   const relativePath = path.relative(dataDir, filePath);
 
-  const frontmatter = {
+  const frontmatter: Record<string, unknown> = {
     type: "graypaper_versions",
     versions: versions.map((v) => ({
       version: v.version,
       timestamp: v.timestamp.toISOString(),
     })),
   };
+  if (latest) {
+    frontmatter.latest_hash = latest.hash;
+    frontmatter.latest_version = latest.version;
+  }
 
   const body = versions
     .map((v) => `- **${v.version}** — ${v.timestamp.toISOString()}`)

--- a/backend/src/mcp/server.ts
+++ b/backend/src/mcp/server.ts
@@ -66,7 +66,7 @@ export function createMcpServer(db: SearchDB, dataDir: string): Server {
           const spec = specFor("get_full_document");
           if (!spec) throw new Error("get_full_document spec missing");
           const parsed = spec.schema.parse(args) as { id: string };
-          const doc = await executeGetFullDocument(parsed, db);
+          const doc = await executeGetFullDocument(parsed, db, dataDir);
           if (!doc) {
             return {
               content: [

--- a/backend/src/scripts/updateGraypaperVersions.ts
+++ b/backend/src/scripts/updateGraypaperVersions.ts
@@ -62,9 +62,8 @@ export async function updateGraypaperVersions(
 
   const latest = resolveLatest(metadata);
   const latestChanged =
-    latest !== null &&
-    (latest.hash !== existing.latestHash ||
-      latest.version !== existing.latestVersion);
+    (latest?.hash ?? null) !== existing.latestHash ||
+    (latest?.version ?? null) !== existing.latestVersion;
 
   if (hasNewVersion || latestChanged) {
     writeGraypaperVersions(
@@ -73,7 +72,7 @@ export async function updateGraypaperVersions(
         version: v.version,
         timestamp: new Date(v.timestamp),
       })),
-      latest ?? undefined
+      latest
     );
   }
 

--- a/backend/src/scripts/updateGraypaperVersions.ts
+++ b/backend/src/scripts/updateGraypaperVersions.ts
@@ -4,31 +4,47 @@ import matter from "gray-matter";
 import { writeGraypaperVersions } from "../data/writer.js";
 import type { ArchiveMetadata } from "../jobs/graypaperJob.js";
 
-function getExistingVersions(
-  dataDir: string
-): Array<{ version: string; timestamp: string }> {
+interface ExistingVersionsFile {
+  versions: Array<{ version: string; timestamp: string }>;
+  latestHash: string | null;
+  latestVersion: string | null;
+}
+
+function getExistingVersions(dataDir: string): ExistingVersionsFile {
   const versionsPath = path.join(dataDir, "graypaper", "versions.md");
   if (!fs.existsSync(versionsPath)) {
-    return [];
+    return { versions: [], latestHash: null, latestVersion: null };
   }
 
   const raw = fs.readFileSync(versionsPath, "utf-8");
   const { data: frontmatter } = matter(raw);
-  return (
-    (frontmatter.versions as Array<{ version: string; timestamp: string }>) ||
-    []
-  );
+  return {
+    versions:
+      (frontmatter.versions as Array<{ version: string; timestamp: string }>) ||
+      [],
+    latestHash: (frontmatter.latest_hash as string) ?? null,
+    latestVersion: (frontmatter.latest_version as string) ?? null,
+  };
+}
+
+function resolveLatest(
+  metadata: ArchiveMetadata
+): { hash: string; version: string } | null {
+  const latestHash = metadata.latest;
+  const latest = metadata.versions[latestHash];
+  if (!latest?.name) return null;
+  return { hash: latestHash, version: latest.name };
 }
 
 export async function updateGraypaperVersions(
   dataDir: string,
   metadata: ArchiveMetadata
 ): Promise<boolean> {
-  const existingVersions = getExistingVersions(dataDir);
-  const existingSet = new Set(existingVersions.map((v) => v.version));
+  const existing = getExistingVersions(dataDir);
+  const existingSet = new Set(existing.versions.map((v) => v.version));
 
-  let hasNew = false;
-  const allVersions = [...existingVersions];
+  let hasNewVersion = false;
+  const allVersions = [...existing.versions];
 
   for (const version of Object.values(metadata.versions)) {
     // Skip legacy versions without a name
@@ -39,20 +55,27 @@ export async function updateGraypaperVersions(
         version: version.name,
         timestamp: new Date(version.date).toISOString(),
       });
-      hasNew = true;
+      hasNewVersion = true;
       console.log(`Added new graypaper version: ${version.name}`);
     }
   }
 
-  if (hasNew) {
+  const latest = resolveLatest(metadata);
+  const latestChanged =
+    latest !== null &&
+    (latest.hash !== existing.latestHash ||
+      latest.version !== existing.latestVersion);
+
+  if (hasNewVersion || latestChanged) {
     writeGraypaperVersions(
       dataDir,
       allVersions.map((v) => ({
         version: v.version,
         timestamp: new Date(v.timestamp),
-      }))
+      })),
+      latest ?? undefined
     );
   }
 
-  return hasNew;
+  return hasNewVersion;
 }

--- a/client/src/components/results/GraypaperResults.tsx
+++ b/client/src/components/results/GraypaperResults.tsx
@@ -1,6 +1,8 @@
+import { buildGraypaperUrl } from "@shared/graypaper";
 import { BookOpenText } from "lucide-react";
 import { Link as RouterLink, useLocation } from "react-router-dom";
 import GraypaperReaderLogo from "@/assets/logos/graypaper.png";
+import { useGraypaperLatest } from "@/hooks/useGraypaperLatest";
 import type { useResults } from "@/hooks/useResults";
 import { getTextToDisplay } from "@/lib/utils";
 import { withMathRendering } from "../InlineMath";
@@ -20,6 +22,7 @@ export const GraypaperResults = ({
   query,
 }: GraypaperResultsProps) => {
   const location = useLocation();
+  const latest = useGraypaperLatest();
   const { isLoading, isError, results } = queryResult;
 
   const graypaperReader = {
@@ -74,7 +77,7 @@ export const GraypaperResults = ({
                     <BookOpenText className="h-3 -mr-1" /> Open reader
                   </>
                 }
-                url={`https://graypaper.fluffylabs.dev/#/?search=${query}&section=${section.title}`}
+                url={buildGraypaperUrl(section.title, query, latest)}
                 results={[]}
                 searchQuery={query}
               />

--- a/client/src/hooks/useGraypaperLatest.ts
+++ b/client/src/hooks/useGraypaperLatest.ts
@@ -1,5 +1,5 @@
-import { useQuery } from "@tanstack/react-query";
 import type { GraypaperLatest } from "@shared/graypaper";
+import { useQuery } from "@tanstack/react-query";
 import { fetchGraypaperLatest } from "@/lib/api";
 
 const EMPTY: GraypaperLatest = { hash: null, version: null };

--- a/client/src/hooks/useGraypaperLatest.ts
+++ b/client/src/hooks/useGraypaperLatest.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import type { GraypaperLatest } from "@shared/graypaper";
+import { fetchGraypaperLatest } from "@/lib/api";
+
+const EMPTY: GraypaperLatest = { hash: null, version: null };
+
+/**
+ * Latest graypaper hash + version, fetched once and cached forever within the
+ * session. Consumers receive {hash: null, version: null} until the fetch
+ * resolves; the shared URL composer falls back to the un-pinned URL in that
+ * case.
+ */
+export function useGraypaperLatest(): GraypaperLatest {
+  const { data } = useQuery({
+    queryKey: ["graypaper-latest"],
+    queryFn: fetchGraypaperLatest,
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: Number.POSITIVE_INFINITY,
+  });
+  return data ?? EMPTY;
+}

--- a/client/src/lib/__tests__/graypaperUrl.test.ts
+++ b/client/src/lib/__tests__/graypaperUrl.test.ts
@@ -1,0 +1,43 @@
+import { buildGraypaperUrl } from "@shared/graypaper";
+import { describe, expect, it } from "vitest";
+
+describe("buildGraypaperUrl", () => {
+  it("includes a 7-char short hash and version when latest is known", () => {
+    const url = buildGraypaperUrl("Accumulate", "work results", {
+      hash: "ab2cdbd5b070ba2176e8dd830b06401ce05a954d",
+      version: "0.7.2",
+    });
+    expect(url).toBe(
+      "https://graypaper.fluffylabs.dev/#/ab2cdbd?v=0.7.2&search=work results&section=Accumulate"
+    );
+  });
+
+  it("falls back to the un-pinned URL when hash is missing", () => {
+    const url = buildGraypaperUrl("Accumulate", "work", {
+      hash: null,
+      version: "0.7.2",
+    });
+    expect(url).toBe(
+      "https://graypaper.fluffylabs.dev/#/?search=work&section=Accumulate"
+    );
+  });
+
+  it("falls back when version is missing", () => {
+    const url = buildGraypaperUrl("Accumulate", "work", {
+      hash: "ab2cdbd5b070ba2176e8dd830b06401ce05a954d",
+      version: null,
+    });
+    expect(url).toBe(
+      "https://graypaper.fluffylabs.dev/#/?search=work&section=Accumulate"
+    );
+  });
+
+  it("does not URL-encode title or query (matches reader's hash router)", () => {
+    const url = buildGraypaperUrl("Section With Space", "two words", {
+      hash: "ab2cdbd5b070ba2176e8dd830b06401ce05a954d",
+      version: "0.7.2",
+    });
+    expect(url).toContain("section=Section With Space");
+    expect(url).toContain("search=two words");
+  });
+});

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -2,6 +2,7 @@
  * API client for making network requests
  */
 
+import type { GraypaperLatest } from "@shared/graypaper";
 import type { ContentKind } from "@shared/pages";
 
 // Base URL for API requests
@@ -187,6 +188,10 @@ export async function searchGraypaper(
   queryParams.append("pageSize", pageSize.toString());
 
   return fetchApi(`/search/graypaper?${queryParams.toString()}`);
+}
+
+export async function fetchGraypaperLatest(): Promise<GraypaperLatest> {
+  return fetchApi<GraypaperLatest>("/graypaper/latest");
 }
 
 export interface PageSearchResponse {

--- a/client/src/pages/viewall/graypaper.tsx
+++ b/client/src/pages/viewall/graypaper.tsx
@@ -1,3 +1,4 @@
+import { buildGraypaperUrl } from "@shared/graypaper";
 import { ArrowLeft } from "lucide-react";
 import { useRef } from "react";
 import { Link, useLocation } from "react-router-dom";
@@ -11,6 +12,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ViewEmbedded } from "@/components/ViewEmbedded";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { useEmbedding } from "@/hooks/useEmbedding";
+import { useGraypaperLatest } from "@/hooks/useGraypaperLatest";
 import { useSearchGraypaper } from "@/hooks/useSearchGraypaper";
 import { SearchMode } from "@/lib/mode";
 import { getTextToDisplay } from "@/lib/utils";
@@ -24,6 +26,7 @@ const GraypaperResultsAll = () => {
   useDocumentTitle(query || null);
 
   const embedding = useEmbedding(query, searchMode !== SearchMode.Regular).data;
+  const latest = useGraypaperLatest();
   const queryResult = useSearchGraypaper({
     query,
     embedding,
@@ -87,7 +90,7 @@ const GraypaperResultsAll = () => {
                       title={section.title}
                       text={section.text}
                       query={query}
-                      url={`https://graypaper.fluffylabs.dev/#/?search=${query}&section=${section.title}`}
+                      url={buildGraypaperUrl(section.title, query, latest)}
                     />
                   ))}
                 </div>

--- a/data/graypaper/versions.md
+++ b/data/graypaper/versions.md
@@ -1,5 +1,7 @@
 ---
 type: graypaper_versions
+latest_hash: ab2cdbd5b070ba2176e8dd830b06401ce05a954d
+latest_version: 0.7.2
 versions:
   - version: 0.3.7
     timestamp: '2024-09-11T04:31:45.000Z'

--- a/shared/graypaper.ts
+++ b/shared/graypaper.ts
@@ -1,0 +1,23 @@
+export interface GraypaperLatest {
+  hash: string | null;
+  version: string | null;
+}
+
+const READER_BASE = "https://graypaper.fluffylabs.dev/#/";
+const SHORT_HASH_LEN = 7;
+
+// The Graypaper reader's hash router treats `query` and `title` as raw
+// path-after-fragment text — encoding them breaks the existing search/section
+// parsing. Keep them un-encoded to match the reader's expectations.
+export function buildGraypaperUrl(
+  title: string,
+  query: string,
+  latest: GraypaperLatest
+): string {
+  const params = `search=${query}&section=${title}`;
+  if (!latest.hash || !latest.version) {
+    return `${READER_BASE}?${params}`;
+  }
+  const shortHash = latest.hash.slice(0, SHORT_HASH_LEN);
+  return `${READER_BASE}${shortHash}?v=${latest.version}&${params}`;
+}

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -1,4 +1,5 @@
 export * as discord from "./discord.js";
 export * as github from "./github.js";
+export * as graypaper from "./graypaper.js";
 export * as matrix from "./matrix.js";
 export * as pages from "./pages.js";


### PR DESCRIPTION
## Summary
- Result links now use `https://graypaper.fluffylabs.dev/#/<shortHash>?v=<version>&search=...&section=...`, skipping the reader's client-side redirect.
- The latest hash + version is persisted in `data/graypaper/versions.md` frontmatter (captured by `updateGraypaperVersions` from `metadata.json`) and exposed via `GET /graypaper/latest`.
- Single URL composer in `shared/graypaper.ts` is shared between backend (`tools.ts`, AI agent citations) and frontend (results pages, via a `useGraypaperLatest` hook).

## Test plan
- [ ] Search for a graypaper section and click "Open reader" — URL contains `#/ab2cdbd?v=0.7.2&...` and the reader opens directly with no redirect.
- [ ] Same check on the "View all graypaper" page.
- [ ] Ask the AI a graypaper question and confirm citation links use the new format.
- [ ] `GET /graypaper/latest` returns `{hash, version}`.
- [ ] On a stale data dir (no `latest_hash` in versions.md), composer falls back to the un-pinned URL — links still work.
- [ ] `npm run qa` (lint + biome) and `npm test` pass on both backend and client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Graypaper reader links now use a fetched "latest" reference so embedded readers and "Open reader" links point to the current version instead of a hardcoded URL.
  * New endpoint exposes the latest graypaper metadata for clients to consume.

* **Tests**
  * Added tests validating latest-version behavior, caching, and preservation/clearing of pinned latest metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->