### PR TITLE
chore(deps): bump typescript to 6.0.3

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -6,8 +6,9 @@
     "skipLibCheck": true,
     "types": ["node"],
     "outDir": "dist/",
+    "rootDir": "..",
     "noEmit": true
   },
   "exclude": ["node_modules", "src/scripts/exportToMarkdown.ts"],
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "../shared/**/*"]
 }

--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -19,7 +19,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@shared/*": ["../shared/*"]

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -5,7 +5,6 @@
     { "path": "./tsconfig.node.json" }
   ],
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@shared/*": ["../shared/*"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",
-        "typescript": "^5.8.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": "25.x",
@@ -10406,9 +10406,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   },
   "overrides": {
     "zod": "^4.3.6"


### PR DESCRIPTION
## Summary

Bumps `typescript` from 5.9.3 to 6.0.3 (supersedes #257 by including the required tsconfig migrations).

TypeScript 6 introduced two breaking changes that prevented the bare dependabot bump from compiling:

- **Stricter `rootDir` enforcement** — backend imports `../../../shared/*.js`, which TS6 now flags with `TS6059` because shared/ sits outside the inferred rootDir.
- **`baseUrl` is now an error** — `TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0`.

## Changes

- `backend/tsconfig.json`: explicitly set `rootDir: ".."` and add `../shared/**/*` to `include`. Backend has `noEmit: true` and runs via `tsx`, so widening rootDir has no runtime impact.
- `client/tsconfig.json` and `client/tsconfig.app.json`: drop `baseUrl`. `paths` resolves relative to the tsconfig location in TypeScript 5.4+, and Vite's path resolution is configured separately in `vite.config.ts`.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm run test` (97 backend + 90 client tests pass)
- [x] `npm run qa` (only the pre-existing biome warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated TypeScript development tooling to version 6.0.3
  * Refined build configuration for improved module resolution handling

---

**Note:** This release primarily includes internal development tooling and build configuration updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->